### PR TITLE
Add editorconfig with line length 100

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = LF
+charset = utf-8
+
+[*.py]
+max_line_length = 100


### PR DESCRIPTION
This doesn't change what pylint enforces. It only changes what your code editor shows as the line limit.

This of course only works in code editors that use the `.editorconfig` file. Editors that do this natively are:

* PyCharm
* VisualStudio

There are also Plugins for the following editors:

* Atom
* VSCode
* eclipse
* emacs
* (many more)

source: https://editorconfig.org/#download