### PR TITLE
Add evaluation loop for threaded algorithms

### DIFF
--- a/ethicml/evaluators/evaluate_models.py
+++ b/ethicml/evaluators/evaluate_models.py
@@ -9,11 +9,13 @@ from typing import List, Dict, Tuple, Any
 import pandas as pd
 import numpy as np
 
+from ethicml.algorithms.algorithm_base import ThreadedAlgorithm
 from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
 from ethicml.algorithms.inprocess.threaded.threaded_in_algorithm import ThreadedInAlgorithm
 from ethicml.algorithms.postprocess.post_algorithm import PostAlgorithm
 from ethicml.algorithms.preprocess.pre_algorithm import PreAlgorithm
-from ethicml.algorithms.utils import DataTuple, PathTuple
+from ethicml.algorithms.preprocess.threaded.threaded_pre_algorithm import ThreadedPreAlgorithm
+from ethicml.algorithms.utils import DataTuple, PathTuple, write_data_tuple, get_subset
 from ..data.dataset import Dataset
 from ..data.load import load_data
 from .per_sensitive_attribute import metric_per_sensitive_attribute, MetricNotApplicable
@@ -132,6 +134,108 @@ def evaluate_models(datasets: List[Dataset], preprocess_models: List[PreAlgorith
             results.to_csv(f"../results/{dataset.name}_{transform_name}.csv", index=False)
 
 
+def evaluate_threaded_models(datasets: List[Dataset], preprocess_models: List[ThreadedPreAlgorithm],
+                             inprocess_models: List[ThreadedInAlgorithm],
+                             postprocess_models: List[PostAlgorithm], metrics: List[Metric],
+                             per_sens_metrics: List[Metric], test_mode: bool = False):
+    """Evaluate all the given models for all the given datasets and compute all the given metrics
+
+    This function only works with threaded models.
+
+    Args:
+        datasets: list of dataset objects
+        preprocess_models: list of preprocess model objects
+        inprocess_models: list of inprocess model objects
+        postprocess_models: list of postprocess model objects
+        metrics: list of metric objects
+        per_sens_metrics: list of metric objects that will be evaluated per sensitive attribute
+        test_mode: if True, only use a small subset of the data so that the models run faster
+    """
+    per_sens_metrics_check(per_sens_metrics)
+
+    for dataset in datasets:
+        train: DataTuple
+        test: DataTuple
+        train, test = train_test_split(load_data(dataset))
+        if test_mode:
+            train = get_subset(train)  # take smaller subset of training data to speed up evaluation
+
+        with TemporaryDirectory() as tmpdir:  # a new temp dir per dataset
+            tmp_path = Path(tmpdir)
+
+            # write the files for the non-transformed data
+            # we apply a scope to the paths in order to avoid name duplications (not really needed)
+            no_transform_dir = tmp_path / "no_transform"
+            train_paths, test_paths = write_data_tuple(train, test, no_transform_dir)
+            to_operate_on: Dict[str, Any] = {"no_transform": {
+                'train_paths': train_paths, 'test_paths': test_paths, 'tmp_path': no_transform_dir}}
+
+            for pre_process_method in preprocess_models:
+                # separate directory for each preprocessing model
+                model_dir = subdir_for_model(tmp_path, pre_process_method)
+                new_train, new_test = pre_process_method.run(train_paths, test_paths, model_dir)
+
+                # write the returned data to a new file
+                # (this step could be avoided if the models would return the paths to the output
+                # directly instead of first reading the data themselves and then returning it here)
+                new_train_paths, new_test_paths = write_data_tuple(
+                    DataTuple(x=new_train, s=train.s, y=train.y),
+                    DataTuple(x=new_test, s=test.s, y=test.y), model_dir)
+
+                to_operate_on[pre_process_method.name] = {'train_paths': new_train_paths,
+                                                          'test_paths': new_test_paths,
+                                                          'tmp_path': model_dir}
+
+            columns = ['model']
+            columns += [metric.name for metric in metrics]
+            columns += get_sensitive_combinations(per_sens_metrics, train)
+
+            temp_res: Dict[str, Any] = {}
+
+            transform_name: str
+            for transform_name, transform in to_operate_on.items():
+                results = pd.DataFrame(columns=columns)
+
+                transformed_train: PathTuple = transform['train_paths']
+                transformed_test: PathTuple = transform['test_paths']
+                # separate directory for each transformed data set (this should already exist)
+                transform_dir: Path = transform['tmp_path']
+
+                for model in inprocess_models:
+                    # separate directory for each model
+                    model_dir = subdir_for_model(transform_dir, model)
+
+                    temp_res['model'] = model.name
+
+                    predictions: pd.DataFrame = model.run(transformed_train, transformed_test,
+                                                          model_dir)
+
+                    for metric in metrics:
+                        temp_res[metric.name] = metric.score(predictions, test)
+
+                    for metric in per_sens_metrics:
+                        per_sens = metric_per_sensitive_attribute(predictions, test, metric)
+                        for key, value in per_sens.items():
+                            temp_res[f'{key}_{metric.name}'] = value
+
+                    for postprocess in postprocess_models:
+                        # Post-processing has yet to be defined
+                        # - leaving blank until we have an implementation to work with
+                        pass
+
+                    results = results.append(temp_res, ignore_index=True)
+                outdir = Path('..') / 'results'  # OS-independent way of saying '../results'
+                outdir.mkdir(exist_ok=True)
+                results.to_csv(outdir / f"{dataset.name}_{transform_name}.csv", index=False)
+
+
+def subdir_for_model(parent_dir: Path, model: ThreadedAlgorithm) -> Path:
+    """Create a subdirectory in `parent_dir` based on the name of the given model"""
+    model_dir = parent_dir / model.name.strip().replace(' ', '_')
+    model_dir.mkdir(parents=False, exist_ok=False)
+    return model_dir
+
+
 def call_on_saved_data(algorithm: ThreadedInAlgorithm, train: DataTuple, test: DataTuple) -> (
         pd.DataFrame):
     """
@@ -148,15 +252,7 @@ def call_on_saved_data(algorithm: ThreadedInAlgorithm, train: DataTuple, test: D
     """
     with TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
-        train_paths: Dict[str, Path] = {}
-        test_paths: Dict[str, Path] = {}
-        for data_tuple, data_paths, prefix in [(train, train_paths, "train"),
-                                               (test, test_paths, "test")]:
-            data_dict = data_tuple._asdict()
-            for key, data in data_dict.items():
-                data_path = tmp_path / Path(f"data_{prefix}_{key}.parquet")
-                data.to_parquet(data_path, compression=None)
-                data_paths[key] = data_path
+        train_paths, test_paths = write_data_tuple(train, test, tmp_path)
         # call the algorithm with the paths to the saved files and with the path to the temp dir
-        result = algorithm.run(PathTuple(**train_paths), PathTuple(**test_paths), tmp_path)
+        result = algorithm.run(train_paths, test_paths, tmp_path)
     return result

--- a/tests/metric_test.py
+++ b/tests/metric_test.py
@@ -13,6 +13,7 @@ from ethicml.algorithms.inprocess.svm import SVM
 from ethicml.algorithms.utils import DataTuple
 from ethicml.data import Adult
 from ethicml.data.load import load_data
+from ethicml.evaluators.evaluate_models import run_metrics
 from ethicml.evaluators.per_sensitive_attribute import (
     metric_per_sensitive_attribute, diff_per_sensitive_attribute,
     ratio_per_sensitive_attribute, MetricNotApplicable
@@ -291,6 +292,16 @@ def test_tnr_diff():
     nmi_diff = diff_per_sensitive_attribute(nmis)
     print(nmi_diff)
     assert nmi_diff["s_0-s_1"] == 0.09100391134289443
+
+
+def test_run_metrics():
+    train, test = get_train_test()
+    model: InAlgorithm = SVM()
+    predictions: np.array = model.run(train, test)
+    results = run_metrics(predictions, test, [CV()], [TPR()])
+    np.testing.assert_allclose(results['s_0_TPR'], 0.8428571428571429)
+    np.testing.assert_allclose(results['s_1_TPR'], 0.8865248226950354)
+    np.testing.assert_allclose(results['CV'], 0.665)
 
 
 def test_nmi_diff_non_binary_race():


### PR DESCRIPTION
There is right now unfortunately a lot of code duplication between `evaluate_models()` and `evaluate_threaded_models()`. (Fortunately or unfortunately, pylint only cares about similarities between different files.) This duplication can hopefully be significantly reduced later. I didn't want to put too much work into de-duplication only for us to delete one of the two functions.