### PR TITLE
Remove print statement from exception definition

### DIFF
--- a/ethicml/evaluators/evaluate_models.py
+++ b/ethicml/evaluators/evaluate_models.py
@@ -48,7 +48,8 @@ def per_sens_metrics_check(per_sens_metrics: List[Metric]):
     """
     for metric in per_sens_metrics:
         if not metric.apply_per_sensitive:
-            raise MetricNotApplicable()
+            raise MetricNotApplicable(f"Metric {metric.name} is not applicable per sensitive "
+                                      f"attribute, apply to whole dataset instead")
 
 
 def evaluate_models(datasets: List[Dataset], preprocess_models: List[PreAlgorithm],

--- a/ethicml/evaluators/per_sensitive_attribute.py
+++ b/ethicml/evaluators/per_sensitive_attribute.py
@@ -10,7 +10,7 @@ from ..algorithms.utils import DataTuple
 
 
 class MetricNotApplicable(Exception):
-    print("Metric Not Applicable per sensitive attribute, apply to whole dataset instead")
+    """Metric Not Applicable per sensitive attribute, apply to whole dataset instead"""
 
 
 def metric_per_sensitive_attribute(
@@ -19,7 +19,8 @@ def metric_per_sensitive_attribute(
         metric: Metric) -> Dict[str, float]:
     """Compute a metric repeatedly on subsets of the data that share a senstitive attribute"""
     if not metric.apply_per_sensitive:
-        raise MetricNotApplicable()
+        raise MetricNotApplicable(f"Metric {metric.name} is not applicable per sensitive "
+                                  f"attribute, apply to whole dataset instead")
 
     amalgamated = pd.concat([actual.x,
                              actual.s,


### PR DESCRIPTION
This was causing a print every time `ethicml` was imported:

```
>>> import ethicml
Metric Not Applicable per sensitive attribute, apply to whole dataset instead
```

Apparently, you shouldn't put a print statement there. I followed this advice: https://www.programiz.com/python-programming/user-defined-exception to fix the problem.

Now it works nicely:

```
>>> import ethicml
>>> ethicml.evaluators.evaluate_models.per_sens_metrics_check([ethicml.metrics.CV()])
---------------------------------------------------------------------------
MetricNotApplicable                       Traceback (most recent call last)
<ipython-input-5-6062284beb0a> in <module>
      1 import ethicml
----> 2 ethicml.evaluators.evaluate_models.per_sens_metrics_check([ethicml.metrics.CV()])

~/PycharmProjects/ethicml/ethicml/evaluators/evaluate_models.py in per_sens_metrics_check(per_sens_metrics)
     49     for metric in per_sens_metrics:
     50         if not metric.apply_per_sensitive:
---> 51             raise MetricNotApplicable(f"Metric {metric.name} is not applicable per sensitive "
     52                                       f"attribute, apply to whole dataset instead")
     53 

MetricNotApplicable: Metric CV is not applicable per sensitive attribute, apply to whole dataset instead
```