### PR TITLE
Use setuptools instead of distutils in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='EthicML',


### PR DESCRIPTION
`distutils` is old and lacks some features. In particular, I found that `pip install -e .` was not working correctly with distutils. Using setuptools has solved that problem.