### PR TITLE
Separate implementation of algorithms from class definition of the algorithms

### DIFF
--- a/ethicml/algorithms/algorithm_base.py
+++ b/ethicml/algorithms/algorithm_base.py
@@ -4,12 +4,12 @@ Base class for Algorithms
 import sys
 from pathlib import Path
 from abc import ABC, abstractmethod
-from typing import List, Optional, Dict, Tuple
+from typing import List, Optional, Dict
 from subprocess import check_call, CalledProcessError
 
 import pandas as pd
 
-from .utils import PathTuple, DataTuple
+from .utils import PathTuple
 
 
 def load_dataframe(path: Path) -> pd.DataFrame:
@@ -22,7 +22,6 @@ def load_dataframe(path: Path) -> pd.DataFrame:
 class Algorithm(ABC):
     """Base class for Algorithms"""
     def __init__(self, executable: Optional[str] = None,
-                 args: Optional[List[str]] = None,
                  hyperparams: Dict[str, float] = None):
         """Constructor
 
@@ -36,7 +35,6 @@ class Algorithm(ABC):
             executable = sys.executable
         self.executable: str = executable
         self.hyperparams = hyperparams
-        self.args = sys.argv[1:] if args is None else args
 
     @property
     @abstractmethod
@@ -60,20 +58,6 @@ class Algorithm(ABC):
             check_call(cmd, env=env)
         except CalledProcessError:
             raise RuntimeError(f'The script failed. Supplied arguments: {cmd_args}')
-
-    def load_data(self) -> Tuple[DataTuple, DataTuple]:
-        """Load the data from the files"""
-        train = DataTuple(
-            x=load_dataframe(Path(self.args[0])),
-            s=load_dataframe(Path(self.args[1])),
-            y=load_dataframe(Path(self.args[2])),
-        )
-        test = DataTuple(
-            x=load_dataframe(Path(self.args[3])),
-            s=load_dataframe(Path(self.args[4])),
-            y=load_dataframe(Path(self.args[5])),
-        )
-        return train, test
 
     @staticmethod
     def _path_tuple_to_cmd_args(path_tuples: List[PathTuple], prefixes: List[str]) -> List[str]:

--- a/ethicml/algorithms/inprocess/installed_model.py
+++ b/ethicml/algorithms/inprocess/installed_model.py
@@ -64,16 +64,12 @@ class InstalledModel(InAlgorithm):
     def _run(self, train, test):
         pass
 
-    def run_thread(self, train_paths, test_paths, tmp_path):
+    def _script_command(self, train_paths, test_paths, pred_path):
         """
         Overridden from parent - see there
-
         """
-        pred_path = tmp_path / "predictions.feather"
-        args = self._script_interface(train_paths, test_paths, pred_path)
-        self._call_script(
-            [f"/{ROOT_DIR}/{self.repo_name}/{self.module}/{self.file_name}"] + args)
-        return pred_path
+        args = self._conventional_interface(train_paths, test_paths, pred_path)
+        return [f"/{ROOT_DIR}/{self.repo_name}/{self.module}/{self.file_name}"] + args
 
     def remove(self):
         """

--- a/ethicml/algorithms/inprocess/logistic_regression.py
+++ b/ethicml/algorithms/inprocess/logistic_regression.py
@@ -3,34 +3,26 @@ Wrapper around Sci-Kit Learn Logistic Regression
 """
 from typing import Optional
 
-import pandas as pd
 from sklearn.linear_model import LogisticRegression
 
 from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.implementations import logistic_regression
 
 
 class LR(InAlgorithm):
     """Logistic regression with hard predictions"""
-    def __init__(self, C: Optional[int] = None):
+    def __init__(self, C: Optional[float] = None):
         super().__init__()
         self.C = LogisticRegression().C if C is None else C
 
     def _run(self, train, test):
-        clf = LogisticRegression(solver='liblinear', random_state=888, C=self.C)
-        clf.fit(train.x, train.y.values.ravel())
-        return pd.DataFrame(clf.predict(test.x), columns=["preds"])
+        return logistic_regression.train_and_predict(train, test, self.C)
+
+    def _script_command(self, train_paths, test_paths, pred_path):
+        script = ['-m', logistic_regression.train_and_predict.__module__]
+        args = self._conventional_interface(train_paths, test_paths, pred_path, str(self.C))
+        return script + args
 
     @property
     def name(self) -> str:
         return "Logistic Regression"
-
-
-def main():
-    """main method to run model"""
-    model = LR()
-    train, test = model.load_data()
-    model.save_predictions(model.run(train, test))
-
-
-if __name__ == "__main__":
-    main()

--- a/ethicml/algorithms/inprocess/logistic_regression_cross_validated.py
+++ b/ethicml/algorithms/inprocess/logistic_regression_cross_validated.py
@@ -2,35 +2,20 @@
 Implementation of cross validated LR. This is a work around for now,
 long term we'll have a proper cross-validation mechanism
 """
-
-import pandas as pd
-
-from sklearn.linear_model import LogisticRegressionCV
-from sklearn.model_selection import KFold
-
 from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.implementations import logistic_regression_cross_validated
 
 
 class LRCV(InAlgorithm):
-
     """Kind of a cheap hack for now, but gives a proper cross-valudeted LR"""
     def _run(self, train, test):
-        folder = KFold(n_splits=3, random_state=888, shuffle=False)
-        clf = LogisticRegressionCV(cv=folder, n_jobs=-1, random_state=888, solver='liblinear')
-        clf.fit(train.x, train.y.values.ravel())
-        return pd.DataFrame(clf.predict(test.x), columns=["preds"])
+        return logistic_regression_cross_validated.train_and_predict(train, test)
+
+    def _script_command(self, train_paths, test_paths, pred_path):
+        script = ['-m', logistic_regression_cross_validated.train_and_predict.__module__]
+        args = self._conventional_interface(train_paths, test_paths, pred_path)
+        return script + args
 
     @property
     def name(self) -> str:
         return "LRCV"
-
-
-def main():
-    """main method to run model"""
-    model = LRCV()
-    train, test = model.load_data()
-    model.save_predictions(model.run(train, test))
-
-
-if __name__ == "__main__":
-    main()

--- a/ethicml/algorithms/inprocess/logistic_regression_probability.py
+++ b/ethicml/algorithms/inprocess/logistic_regression_probability.py
@@ -3,10 +3,10 @@ Logistic regaression with soft output
 """
 from typing import Optional
 
-import pandas as pd
 from sklearn.linear_model import LogisticRegression
 
 from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.implementations import logistic_regression_probability
 
 
 class LRProb(InAlgorithm):
@@ -16,21 +16,13 @@ class LRProb(InAlgorithm):
         self.C = LogisticRegression().C if C is None else C
 
     def _run(self, train, test):
-        clf = LogisticRegression(solver='liblinear', random_state=888)
-        clf.fit(train.x, train.y.values.ravel())
-        return pd.DataFrame(clf.predict_proba(test.x)[:, 1], columns=["preds"])
+        return logistic_regression_probability.train_and_predict(train, test, self.C)
+
+    def _script_command(self, train_paths, test_paths, pred_path):
+        script = ['-m', logistic_regression_probability.train_and_predict.__module__]
+        args = self._conventional_interface(train_paths, test_paths, pred_path, str(self.C))
+        return script + args
 
     @property
     def name(self) -> str:
         return "Logistic Regression Prob"
-
-
-def main():
-    """main method to run model"""
-    model = LRProb()
-    train, test = model.load_data()
-    model.save_predictions(model.run(train, test))
-
-
-if __name__ == "__main__":
-    main()

--- a/ethicml/algorithms/inprocess/svm.py
+++ b/ethicml/algorithms/inprocess/svm.py
@@ -1,36 +1,30 @@
 """
 Wrapper for SKLearn implementation of SVM
 """
-import pandas as pd
+from typing import Optional
+
 from sklearn.svm import SVC
 
 from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.implementations import svm
 
 
 class SVM(InAlgorithm):
     """Support Vector Machine"""
-    def __init__(self, C=None, kernel=None):
+    def __init__(self, C: Optional[float] = None, kernel: Optional[str] = None):
         super().__init__()
-        self.C = C
         self.C = SVC().C if C is None else C
         self.kernel = SVC().kernel if kernel is None else kernel
 
     def _run(self, train, test):
-        clf = SVC(gamma='auto', random_state=888, C=self.C, kernel=self.kernel)
-        clf.fit(train.x, train.y.values.ravel())
-        return pd.DataFrame(clf.predict(test.x), columns=["preds"])
+        return svm.train_and_predict(train, test, self.C, self.kernel)
+
+    def _script_command(self, train_paths, test_paths, pred_path):
+        script = ['-m', svm.train_and_predict.__module__]
+        args = self._conventional_interface(
+            train_paths, test_paths, pred_path, str(self.C), str(self.kernel))
+        return script + args
 
     @property
     def name(self) -> str:
         return "SVM"
-
-
-def main():
-    """main method to run model"""
-    model = SVM()
-    train, test = model.load_data()
-    model.save_predictions(model.run(train, test))
-
-
-if __name__ == "__main__":
-    main()

--- a/ethicml/implementations/common_in.py
+++ b/ethicml/implementations/common_in.py
@@ -1,0 +1,43 @@
+"""Functions that are common to the threaded algorithms"""
+import sys
+from pathlib import Path
+from typing import Tuple, Union, List, Optional
+
+import pandas as pd
+import numpy as np
+
+from ..algorithms.utils import DataTuple
+from ..algorithms.algorithm_base import load_dataframe
+
+
+class InAlgoInterface:
+    """Commandline "interface" for in-process algorithms"""
+    def __init__(self, args: Optional[List[str]] = None):
+        self.args = sys.argv[1:] if args is None else args
+
+    def load_data(self) -> Tuple[DataTuple, DataTuple]:
+        """Load the data from the files"""
+        train = DataTuple(
+            x=load_dataframe(Path(self.args[0])),
+            s=load_dataframe(Path(self.args[1])),
+            y=load_dataframe(Path(self.args[2])),
+        )
+        test = DataTuple(
+            x=load_dataframe(Path(self.args[3])),
+            s=load_dataframe(Path(self.args[4])),
+            y=load_dataframe(Path(self.args[5])),
+        )
+        return train, test
+
+    def save_predictions(self, predictions: Union[np.ndarray, pd.DataFrame]):
+        """Save the data to the file that was specified in the commandline arguments"""
+        if not isinstance(predictions, pd.DataFrame):
+            df = pd.DataFrame(predictions, columns=["pred"])
+        else:
+            df = predictions
+        pred_path = Path(self.args[6])
+        df.to_feather(pred_path)
+
+    def remaining_args(self):
+        """Additional commandline arguments beyond the data paths and the prediction path"""
+        return self.args[7:]

--- a/ethicml/implementations/logistic_regression.py
+++ b/ethicml/implementations/logistic_regression.py
@@ -1,0 +1,25 @@
+"""Implementation of logistic regression (actually just a wrapper around sklearn)"""
+from sklearn.linear_model import LogisticRegression
+
+import pandas as pd
+
+from .common_in import InAlgoInterface
+
+
+def train_and_predict(train, test, C):
+    """Train a logistic regression model and compute predictions on the given test data"""
+    clf = LogisticRegression(solver='liblinear', random_state=888, C=C)
+    clf.fit(train.x, train.y.values.ravel())
+    return pd.DataFrame(clf.predict(test.x), columns=["preds"])
+
+
+def main():
+    """main method to run model"""
+    interface = InAlgoInterface()
+    train, test = interface.load_data()
+    C, = interface.remaining_args()
+    interface.save_predictions(train_and_predict(train, test, C=float(C)))
+
+
+if __name__ == "__main__":
+    main()

--- a/ethicml/implementations/logistic_regression_cross_validated.py
+++ b/ethicml/implementations/logistic_regression_cross_validated.py
@@ -1,0 +1,26 @@
+"""Implementation of logistic regression (actually just a wrapper around sklearn)"""
+from sklearn.linear_model import LogisticRegressionCV
+from sklearn.model_selection import KFold
+
+import pandas as pd
+
+from .common_in import InAlgoInterface
+
+
+def train_and_predict(train, test):
+    """Train a logistic regression model and compute predictions on the given test data"""
+    folder = KFold(n_splits=3, random_state=888, shuffle=False)
+    clf = LogisticRegressionCV(cv=folder, n_jobs=-1, random_state=888, solver='liblinear')
+    clf.fit(train.x, train.y.values.ravel())
+    return pd.DataFrame(clf.predict(test.x), columns=["preds"])
+
+
+def main():
+    """main method to run model"""
+    interface = InAlgoInterface()
+    train, test = interface.load_data()
+    interface.save_predictions(train_and_predict(train, test))
+
+
+if __name__ == "__main__":
+    main()

--- a/ethicml/implementations/logistic_regression_probability.py
+++ b/ethicml/implementations/logistic_regression_probability.py
@@ -1,0 +1,27 @@
+"""
+Logistic regaression with soft output
+"""
+from sklearn.linear_model import LogisticRegression
+
+import pandas as pd
+
+from .common_in import InAlgoInterface
+
+
+def train_and_predict(train, test, C):
+    """Train a logistic regression model and compute predictions on the given test data"""
+    clf = LogisticRegression(solver='liblinear', random_state=888, C=C)
+    clf.fit(train.x, train.y.values.ravel())
+    return pd.DataFrame(clf.predict_proba(test.x)[:, 1], columns=["preds"])
+
+
+def main():
+    """main method to run model"""
+    interface = InAlgoInterface()
+    train, test = interface.load_data()
+    C, = interface.remaining_args()
+    interface.save_predictions(train_and_predict(train, test, float(C)))
+
+
+if __name__ == "__main__":
+    main()

--- a/ethicml/implementations/svm.py
+++ b/ethicml/implementations/svm.py
@@ -1,0 +1,25 @@
+"""Implementation of SVM (actually just a wrapper around sklearn)"""
+from sklearn.svm import SVC
+
+import pandas as pd
+
+from .common_in import InAlgoInterface
+
+
+def train_and_predict(train, test, C, kernel):
+    """Train an SVM model and compute predictions on the given test data"""
+    clf = SVC(gamma='auto', random_state=888, C=C, kernel=kernel)
+    clf.fit(train.x, train.y.values.ravel())
+    return pd.DataFrame(clf.predict(test.x), columns=["preds"])
+
+
+def main():
+    """main method to run model"""
+    interface = InAlgoInterface()
+    train, test = interface.load_data()
+    C, kernel = interface.remaining_args()
+    interface.save_predictions(train_and_predict(train, test, C=float(C), kernel=kernel))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a new submodule: `ethicml.implementations`. This submodule contains the actual implementations of the algorithms.

This separation has the following advantages:

* python packages that are used in the implementations can be loaded on demand
* files don't call themselves anymore
  
   This will make it much easier to understand what is going on. No more `self.module` references that are hidden in some base classes.
* the classes `Algorithm` and `InAlgorithm` were able to get rid of a lot of code that is irrelevant to the algorithm objects. For example: previously each algorithm object previously stored the commandline arguments of the *current* program, even though these are completely irrelevant (only the commandline arguments of subprocesses are relevant)
* the code in `installed_model.py` became shorter and nicer

Other improvements:
* the threaded versions of SVM and logistic regression now receive the hyperparameters `C` and `kernel`. Previously, the didn't receive them
* all functions in `in_algorithm.py` now have complete type annotations

There is a warning from pylint that there is code duplication in `ethicml.implementations.logistic_regression`, `ethicml.implementations.logistic_regression_cross_validated` and `ethicml.implementations.svm`. **I promise I will fix that code duplication in a subsequent PR.** But I think if I do it in this PR, the code changes will be harder to understand.