### PR TITLE
Rename classes to make hierarchy more intuitive

### DIFF
--- a/ethicml/algorithms/inprocess/__init__.py
+++ b/ethicml/algorithms/inprocess/__init__.py
@@ -1,6 +1,6 @@
 """In-process algorithms take training data and make predictions"""
 from .agarwal_reductions import Agarwal
-from .in_algorithm import InAlgorithm, InAlgorithmSync
+from .in_algorithm import InAlgorithm, InAlgorithmAsync
 from .fair_gpyt import GPyT, GPyTDemPar, GPyTEqOdds
 from .kamishima import Kamishima
 from .kamiran import Kamiran

--- a/ethicml/algorithms/inprocess/agarwal_reductions.py
+++ b/ethicml/algorithms/inprocess/agarwal_reductions.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import SVC
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
 from ethicml.algorithms.inprocess.interface import conventional_interface
 from ethicml.algorithms.utils import PathTuple, DataTuple
 from ethicml.implementations import agarwal
@@ -18,7 +18,7 @@ VALID_FAIRNESS = {"DP", "EqOd"}
 VALID_MODELS = {"LR", "SVM"}
 
 
-class Agarwal(InAlgorithm):
+class Agarwal(InAlgorithmAsync):
     """
     Agarwal class
     """

--- a/ethicml/algorithms/inprocess/in_algorithm.py
+++ b/ethicml/algorithms/inprocess/in_algorithm.py
@@ -18,7 +18,7 @@ from ethicml.algorithms.utils import (
 )
 
 
-class InAlgorithmSync(Algorithm):
+class InAlgorithm(Algorithm):
     """Abstract Base Class for algorithms that run in the middle of the pipeline"""
 
     @abstractmethod
@@ -36,7 +36,7 @@ class InAlgorithmSync(Algorithm):
         return self.run(train_testing, test)
 
 
-class InAlgorithm(InAlgorithmSync, AlgorithmAsync):
+class InAlgorithmAsync(InAlgorithm, AlgorithmAsync):
     """In-Algorithm that can be run blocking and asynchronously"""
 
     def run(self, train, test):

--- a/ethicml/algorithms/inprocess/installed_model.py
+++ b/ethicml/algorithms/inprocess/installed_model.py
@@ -12,7 +12,7 @@ import subprocess
 
 import git
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
 from ethicml.algorithms.inprocess.interface import conventional_interface
 from ethicml.common import ROOT_PATH
 
@@ -20,7 +20,7 @@ from ethicml.common import ROOT_PATH
 ROOT_DIR = ROOT_PATH.parent
 
 
-class InstalledModel(InAlgorithm):
+class InstalledModel(InAlgorithmAsync):
     """ the model that does the magic"""
 
     def __init__(self, name: str, url: str, module: str, file_name: str):

--- a/ethicml/algorithms/inprocess/kamiran.py
+++ b/ethicml/algorithms/inprocess/kamiran.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import SVC
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
 from ethicml.algorithms.inprocess.interface import conventional_interface
 from ethicml.algorithms.utils import PathTuple
 from ethicml.implementations import kamiran
@@ -13,7 +13,7 @@ from ethicml.implementations import kamiran
 VALID_MODELS = {"LR", "SVM"}
 
 
-class Kamiran(InAlgorithm):
+class Kamiran(InAlgorithmAsync):
     """
     Kamiran and Calders 2012
     """

--- a/ethicml/algorithms/inprocess/logistic_regression.py
+++ b/ethicml/algorithms/inprocess/logistic_regression.py
@@ -5,12 +5,12 @@ from typing import Optional
 
 from sklearn.linear_model import LogisticRegression
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
 from ethicml.algorithms.inprocess.interface import conventional_interface
 from ethicml.implementations import logistic_regression
 
 
-class LR(InAlgorithm):
+class LR(InAlgorithmAsync):
     """Logistic regression with hard predictions"""
 
     def __init__(self, C: Optional[float] = None):

--- a/ethicml/algorithms/inprocess/logistic_regression_cross_validated.py
+++ b/ethicml/algorithms/inprocess/logistic_regression_cross_validated.py
@@ -2,12 +2,12 @@
 Implementation of cross validated LR. This is a work around for now,
 long term we'll have a proper cross-validation mechanism
 """
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
 from ethicml.algorithms.inprocess.interface import conventional_interface
 from ethicml.implementations import logistic_regression_cross_validated
 
 
-class LRCV(InAlgorithm):
+class LRCV(InAlgorithmAsync):
     """Kind of a cheap hack for now, but gives a proper cross-valudeted LR"""
 
     def run(self, train, test):

--- a/ethicml/algorithms/inprocess/logistic_regression_probability.py
+++ b/ethicml/algorithms/inprocess/logistic_regression_probability.py
@@ -5,12 +5,12 @@ from typing import Optional
 
 from sklearn.linear_model import LogisticRegression
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
 from ethicml.algorithms.inprocess.interface import conventional_interface
 from ethicml.implementations import logistic_regression_probability
 
 
-class LRProb(InAlgorithm):
+class LRProb(InAlgorithmAsync):
     """Logistic regression with soft output"""
 
     def __init__(self, C: Optional[int] = None):

--- a/ethicml/algorithms/inprocess/majority.py
+++ b/ethicml/algorithms/inprocess/majority.py
@@ -4,10 +4,10 @@ Simply returns the majority label from the train set
 
 import pandas as pd
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmSync
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
 
 
-class Majority(InAlgorithmSync):
+class Majority(InAlgorithm):
     """Simply returns the majority label from the train set"""
 
     def run(self, train, test):

--- a/ethicml/algorithms/inprocess/mlp.py
+++ b/ethicml/algorithms/inprocess/mlp.py
@@ -5,12 +5,12 @@ from typing import Optional, Tuple
 
 from sklearn.neural_network import MLPClassifier
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
 from ethicml.algorithms.inprocess.interface import conventional_interface
 from ethicml.implementations import mlp
 
 
-class MLP(InAlgorithm):
+class MLP(InAlgorithmAsync):
     """MLP"""
 
     def __init__(

--- a/ethicml/algorithms/inprocess/svm.py
+++ b/ethicml/algorithms/inprocess/svm.py
@@ -5,12 +5,12 @@ from typing import Optional
 
 from sklearn.svm import SVC
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
 from ethicml.algorithms.inprocess.interface import conventional_interface
 from ethicml.implementations import svm
 
 
-class SVM(InAlgorithm):
+class SVM(InAlgorithmAsync):
     """Support Vector Machine"""
 
     def __init__(self, C: Optional[float] = None, kernel: Optional[str] = None):

--- a/ethicml/algorithms/preprocess/__init__.py
+++ b/ethicml/algorithms/preprocess/__init__.py
@@ -1,5 +1,5 @@
 """Pre-process algorithms take the training data and transform it"""
 from .beutel import Beutel
-from .pre_algorithm import PreAlgorithm, PreAlgorithmSync
+from .pre_algorithm import PreAlgorithmAsync, PreAlgorithm
 from .zemel import Zemel
 from .vfae import VFAE

--- a/ethicml/algorithms/preprocess/beutel.py
+++ b/ethicml/algorithms/preprocess/beutel.py
@@ -1,11 +1,11 @@
 """Beutel's algorithm"""
 from typing import Optional, List, Dict, Union
 
-from .pre_algorithm import PreAlgorithm
+from .pre_algorithm import PreAlgorithmAsync
 from .interface import flag_interface
 
 
-class Beutel(PreAlgorithm):
+class Beutel(PreAlgorithmAsync):
     """Beutel's adversarially learned fair representations"""
 
     def __init__(

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -12,7 +12,7 @@ from ethicml.algorithms.algorithm_base import Algorithm, AlgorithmAsync, run_blo
 from ..utils import get_subset, DataTuple, PathTuple, write_as_feather, load_feather
 
 
-class PreAlgorithmSync(Algorithm):
+class PreAlgorithm(Algorithm):
     """Abstract Base Class for all algorithms that do pre-processing"""
 
     @abstractmethod
@@ -30,7 +30,7 @@ class PreAlgorithmSync(Algorithm):
         return self.run(train_testing, test)
 
 
-class PreAlgorithm(PreAlgorithmSync, AlgorithmAsync):
+class PreAlgorithmAsync(PreAlgorithm, AlgorithmAsync):
     """Pre-Algorithm that can be run blocking and asynchronously"""
 
     def run(self, train, test):

--- a/ethicml/algorithms/preprocess/vfae.py
+++ b/ethicml/algorithms/preprocess/vfae.py
@@ -7,12 +7,12 @@ from typing import List, Tuple, Dict, Union, Optional
 
 import pandas as pd
 
-from ethicml.algorithms.preprocess.pre_algorithm import PreAlgorithm
+from ethicml.algorithms.preprocess.pre_algorithm import PreAlgorithmAsync
 from ethicml.algorithms.preprocess.interface import flag_interface
 from ethicml.algorithms.utils import PathTuple, DataTuple
 
 
-class VFAE(PreAlgorithm):
+class VFAE(PreAlgorithmAsync):
     """
     VFAE Object - see implementation file for details
     """

--- a/ethicml/algorithms/preprocess/zemel.py
+++ b/ethicml/algorithms/preprocess/zemel.py
@@ -3,11 +3,11 @@ Zemel's Learned Fair Representations
 """
 from typing import Dict, Union
 
-from .pre_algorithm import PreAlgorithm
+from .pre_algorithm import PreAlgorithmAsync
 from .interface import flag_interface
 
 
-class Zemel(PreAlgorithm):
+class Zemel(PreAlgorithmAsync):
     """
     AIF360 implementation of Zemel's LFR
     """

--- a/ethicml/evaluators/evaluate_models.py
+++ b/ethicml/evaluators/evaluate_models.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Union
 import pandas as pd
 from tqdm import tqdm
 
-from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmSync
+from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
 from ethicml.algorithms.postprocess.post_algorithm import PostAlgorithm
 from ethicml.algorithms.preprocess.pre_algorithm import PreAlgorithm
 from ethicml.algorithms.utils import DataTuple, get_subset
@@ -77,7 +77,7 @@ def run_metrics(
 def evaluate_models(
     datasets: List[Dataset],
     preprocess_models: List[PreAlgorithm],
-    inprocess_models: List[InAlgorithmSync],
+    inprocess_models: List[InAlgorithm],
     postprocess_models: List[PostAlgorithm],
     metrics: List[Metric],
     per_sens_metrics: List[Metric],

--- a/tests/models_inprocessing_test.py
+++ b/tests/models_inprocessing_test.py
@@ -10,7 +10,7 @@ from ethicml.algorithms.inprocess import (
     GPyTDemPar,
     GPyTEqOdds,
     InAlgorithm,
-    InAlgorithmSync,
+    InAlgorithmAsync,
     Kamishima,
     LRCV,
     LRProb,
@@ -41,7 +41,7 @@ def test_svm():
 def test_majority():
     train, test = get_train_test()
 
-    model: InAlgorithmSync = Majority()
+    model: InAlgorithm = Majority()
     assert model is not None
     assert model.name == "Majority"
 
@@ -111,7 +111,7 @@ def kamishima():
 def test_kamishima(kamishima):
     train, test = get_train_test()
 
-    model: InAlgorithm = kamishima
+    model: InAlgorithmAsync = kamishima
     assert model.name == "Kamishima"
 
     assert model is not None
@@ -135,8 +135,8 @@ def test_gpyt(gpyt_models):
     train, test = get_train_test()
 
     baseline: InAlgorithm = gpyt_models[0]
-    dem_par: InAlgorithm = gpyt_models[1]
-    eq_odds: InAlgorithm = gpyt_models[2]
+    dem_par: InAlgorithmAsync = gpyt_models[1]
+    eq_odds: InAlgorithmAsync = gpyt_models[2]
 
     assert baseline.name == "GPyT_in_True"
     predictions: pd.DataFrame = run_blocking(baseline.run_async(train, test))
@@ -157,7 +157,7 @@ def test_gpyt(gpyt_models):
 def test_threaded_svm():
     train, test = get_train_test()
 
-    model: InAlgorithm = SVM()
+    model: InAlgorithmAsync = SVM()
     assert model is not None
     assert model.name == "SVM"
 
@@ -226,7 +226,7 @@ def test_agarwal():
 def test_threaded_lr():
     train, test = get_train_test()
 
-    model: InAlgorithm = LR()
+    model: InAlgorithmAsync = LR()
     assert model.name == "Logistic Regression"
 
     predictions: pd.DataFrame = run_blocking(model.run_async(train, test))
@@ -241,7 +241,7 @@ def test_threaded_lr():
 def test_threaded_lr_cross_validated():
     train, test = get_train_test()
 
-    model: InAlgorithm = LRCV()
+    model: InAlgorithmAsync = LRCV()
     assert model.name == "LRCV"
 
     predictions: pd.DataFrame = run_blocking(model.run_async(train, test))
@@ -256,7 +256,7 @@ def test_threaded_lr_cross_validated():
 def test_threaded_lr_prob():
     train, test = get_train_test()
 
-    model: InAlgorithm = LRProb()
+    model: InAlgorithmAsync = LRProb()
     assert model.name == "Logistic Regression Prob"
 
     heavi = Heaviside()

--- a/tests/models_preprocessing_test.py
+++ b/tests/models_preprocessing_test.py
@@ -2,8 +2,8 @@ from typing import Tuple
 import pandas as pd
 
 from ethicml.algorithms.algorithm_base import run_blocking
-from ethicml.algorithms.inprocess import InAlgorithm, SVM
-from ethicml.algorithms.preprocess import PreAlgorithm, Beutel, Zemel
+from ethicml.algorithms.inprocess import InAlgorithm, InAlgorithmAsync, SVM
+from ethicml.algorithms.preprocess import PreAlgorithm, PreAlgorithmAsync, Beutel, Zemel
 from ethicml.algorithms.preprocess.vfae import VFAE
 from ethicml.algorithms.utils import DataTuple
 from tests.run_algorithm_test import get_train_test
@@ -122,7 +122,7 @@ def test_zemel():
 def test_threaded_zemel():
     train, test = get_train_test()
 
-    model: PreAlgorithm = Zemel()
+    model: PreAlgorithmAsync = Zemel()
     assert model is not None
     assert model.name == "Zemel"
 
@@ -170,7 +170,7 @@ def test_threaded_zemel():
 def test_threaded_beutel():
     train, test = get_train_test()
 
-    model: PreAlgorithm = Beutel()
+    model: PreAlgorithmAsync = Beutel()
     assert model is not None
     assert model.name == "Beutel"
 
@@ -239,7 +239,7 @@ def test_threaded_custom_beutel():
     assert predictions.values[predictions.values == 1].shape[0] == 202
     assert predictions.values[predictions.values == -1].shape[0] == 198
 
-    model: PreAlgorithm = Beutel(epochs=5, fairness="Eq. Opp")
+    model: PreAlgorithmAsync = Beutel(epochs=5, fairness="Eq. Opp")
     assert model is not None
     assert model.name == "Beutel"
 

--- a/tests/saving_data_test.py
+++ b/tests/saving_data_test.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ethicml.algorithms.utils import DataTuple
 from ethicml.algorithms.algorithm_base import run_blocking
-from ethicml.algorithms.inprocess import InAlgorithm
+from ethicml.algorithms.inprocess import InAlgorithmAsync
 
 
 def test_simple_saving():
@@ -22,7 +22,7 @@ def test_simple_saving():
              'c3': np.array([0, 1, 0])})
     )
 
-    class CheckEquality(InAlgorithm):
+    class CheckEquality(InAlgorithmAsync):
         """Dummy algorithm class for testing whether writing and reading feather files works"""
 
         def name(self):


### PR DESCRIPTION
`InAlgorithm` -> `InAlgorithmAsync`

`InAlgorithmSync` -> `InAlgorithm`

`PreAlgorithm` -> `PreAlgorithmAsync`

`PreAlgorithmSync` -> `PreAlgorithm`