### PR TITLE
Make PyTorch a dev requirement only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EthicML
 
-EthicML exists to combat the problems we've found with off-the-shelf fairness comparison packages.
+EthicML exists to solve the problems we've found with off-the-shelf fairness comparison packages.
 
 These other packages are useful, but given that we primarily do research,
 a lot of the work we do doesn't fit into some nice box.
@@ -19,6 +19,18 @@ IBM's fair-360, Aequitas, EthicalML/XAI, Fairness-Comparison and others.
 They're all great at what they do, they're just not right for us.
 We will however be influenced by them.
 
+## Installation
+
+EthicML requires Python >= 3.6.
+To install EthicML, just do
+```
+pip3 install ethicml
+```
+
+**Attention**: In order to use all features of EthicML, PyTorch needs to be installed separately.
+We are not including PyTorch as a requirement of EthicML,
+because there are many different versions for different systems.
+
 ## Design Principles
 
 ### The Triplet
@@ -34,11 +46,11 @@ All methods must assume S and Y are multi-class.
 We use a named tuple to contain the triplet
 
 ```python
-triplet = DataTuple(x=dataframe, s=dataframe, y=dataframe)
+triplet = DataTuple(x: pandas.DataFrame, s: pandas.DataFrame, y: pandas.DataFrame)
 ```
 
-The dataframe may be a little innefficient,
-but given the amount of splicing on conditions that we're doing it feels worth it.
+The dataframe may be a little inefficient,
+but given the amount of splicing on conditions that we're doing, it feels worth it.
 
 ### Separation of Methods
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         "pandas >= 0.24.0",
         "scikit_learn >= 0.20.1",
         "seaborn >= 0.9.0",
-        "torch >= 1.1.0, <= 1.1.0.post2",
         "pyarrow >= 0.11",
         "numba",
         "fairlearn >= 0.2.0",
@@ -56,6 +55,7 @@ setup(
             "pytest-cov >= 2.6.0",
             "mypy >= 0.720",
             "black",
+            "torch >= 1.1.0, <= 1.1.0.post2",
         ],
     },
 )


### PR DESCRIPTION
Having a specific torch version in the requirements only causes problems it seems.

To make matters worse, it seems that on Windows, you can't install pytorch from pypi at all! You *always* have to install it via a download URL like this
```shell
pip install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp36-cp36m-win_amd64.whl
```
I don't think we can cover all these special cases in our `setup.py`.