### PR TITLE
Change name of Tuple 'copy' function to better reflect functionality.

### DIFF
--- a/ethicml/data/dataset.py
+++ b/ethicml/data/dataset.py
@@ -90,6 +90,15 @@ class Dataset(ABC):
         self._cont_features = feats
 
     @property
+    def discrete_features(self) -> List[str]:
+        """List of features that are discrete"""
+        return self._disc_features
+
+    @discrete_features.setter
+    def discrete_features(self, feats: List[str]) -> None:
+        self._disc_features = feats
+
+    @property
     def features(self) -> List[str]:
         """List of all features"""
         return self._features
@@ -135,14 +144,3 @@ class Dataset(ABC):
     def class_label_prefix(self, label_prefixs: List[str]) -> None:
         self._class_label_prefix = label_prefixs
         self.features_to_remove += label_prefixs
-
-    @property
-    def discrete_features(self) -> List[str]:
-        """List of features that are discrete"""
-        return get_discrete_features(
-            self.features, self.features_to_remove, self.continuous_features
-        )
-
-    @discrete_features.setter
-    def discrete_features(self, feats: List[str]) -> None:
-        self._disc_features = feats

--- a/ethicml/preprocessing/adjust_labels.py
+++ b/ethicml/preprocessing/adjust_labels.py
@@ -45,7 +45,7 @@ class LabelBinarizer:
         assert dataset.y[y_col].nunique() == 2
 
         # make copy of dataset
-        dataset = dataset.make_copy_with(y=dataset.y.copy())
+        dataset = dataset.replace(y=dataset.y.copy())
 
         self.min_val = dataset.y.values.min()
         self.max_val = dataset.y.values.max()
@@ -74,4 +74,4 @@ class LabelBinarizer:
         """Inverse of adjust"""
 
         transformed_y = self.post_only_labels(dataset.y)
-        return dataset.make_copy_with(y=transformed_y)
+        return dataset.replace(y=transformed_y)

--- a/ethicml/preprocessing/feature_binning.py
+++ b/ethicml/preprocessing/feature_binning.py
@@ -25,4 +25,4 @@ def bin_cont_feats(data: DataTuple) -> DataTuple:
             copy = pd.concat([copy, pd.get_dummies(copy[group])], axis="columns")
             copy = copy.drop(group, axis="columns")
 
-    return data.make_copy_with(x=copy)
+    return data.replace(x=copy)

--- a/ethicml/utility/data_structures.py
+++ b/ethicml/utility/data_structures.py
@@ -254,7 +254,6 @@ class FairType(Enum):
         return self.value
 
 
-@dataclass(frozen=True)  # "frozen" means the objects are immutable
-class TrainTestPair:
+class TrainTestPair(NamedTuple):
     train: DataTuple
     test: TestTuple


### PR DESCRIPTION
Make TrainTestPair a dataclass.