### PR TITLE
Slight improvement that came to me in a dream

### DIFF
--- a/ethicml/vision/data/celeba.py
+++ b/ethicml/vision/data/celeba.py
@@ -149,7 +149,7 @@ class CelebA(VisionDataset):
         all_data = all_data.reset_index(drop=False).rename(columns={"index": "filenames"})
 
         attr_names = list(attrs.columns)
-        sens_names: List[str] = list(map(str, sens_attrs))
+        sens_names: List[str] = list(sens_attrs)
 
         # Multiple attributes have been designated as sensitive
         # Note that in this case biased dataset sampling cannot be performed


### PR DESCRIPTION
What mypy really was complaining about there in celeba.py wasn't the fact that it wasn't strings, it was the fact that it wasn't a list. So the `map(str, ...)` wasn't actually needed.