### PR TITLE
Turn the Results class into a NewType(DataFrame)

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -106,4 +106,4 @@ jobs:
         pip install pydocstyle
     - name: Check docstrings with pydocstyle
       run: |
-        pydocstyle --convention=google --ignore-decorator="implements|overload" ethicml
+        python run_pydocstyle.py

--- a/check_all.py
+++ b/check_all.py
@@ -17,7 +17,9 @@ subprocess.call(
     [
         "pydocstyle",
         "--convention=google",
+        "--add-ignore=D105,D107",
         "--ignore-decorators=implements|overload",
+        "--count",
         "-e",
         "ethicml",
     ]

--- a/ethicml/evaluators/cross_validator.py
+++ b/ethicml/evaluators/cross_validator.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from itertools import product
 from statistics import mean
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type, Sequence, Mapping
 
 from ethicml.algorithms.inprocess.in_algorithm import InAlgorithm
 from ethicml.metrics import AbsCV, Accuracy, Metric
@@ -131,7 +131,7 @@ class CrossValidator:
     def __init__(
         self,
         model: Type[InAlgorithm],
-        hyperparams: Dict[str, List[Any]],
+        hyperparams: Mapping[str, Sequence[Any]],
         folds: int = 3,
         max_parallel: int = 0,
     ):

--- a/ethicml/evaluators/evaluate_models.py
+++ b/ethicml/evaluators/evaluate_models.py
@@ -106,7 +106,7 @@ def load_results(
     """
     csv_file = _result_path(outdir, dataset_name, transform_name, topic)
     if csv_file.is_file():
-        return make_results(pd.read_csv(csv_file))
+        return make_results(csv_file)
     return None
 
 
@@ -258,11 +258,11 @@ def evaluate_models(
                     pbar.update()
                 # =========================== end: run inprocess models ===========================
 
-                path_to_file = _result_path(outdir, dataset.name, transform_name, topic)
+                csv_file = _result_path(outdir, dataset.name, transform_name, topic)
                 aggregator = ResultsAggregator(results_df)
                 # put old results before new results -> prepend=True
-                aggregator.append_csv(path_to_file, prepend=True)
-                aggregator.save_as_csv(path_to_file)
+                aggregator.append_from_csv(csv_file, prepend=True)
+                aggregator.save_as_csv(csv_file)
             # ========================== end: loop over preprocessed data =========================
         # =================================== end: one repeat =====================================
 
@@ -272,8 +272,8 @@ def evaluate_models(
     aggregator = ResultsAggregator()  # create empty aggregator object
     for dataset in datasets:
         for transform_name in ["no_transform"] + preprocess_names:
-            path_to_file = _result_path(outdir, dataset.name, transform_name, topic)
-            aggregator.append_csv(path_to_file)
+            csv_file = _result_path(outdir, dataset.name, transform_name, topic)
+            aggregator.append_from_csv(csv_file)
     return aggregator.results
 
 
@@ -426,11 +426,11 @@ def _gather_metrics(
             results_df = results_df.append(df_row, ignore_index=True, sort=False)
 
         # write results to CSV files and load previous results from the files if they already exist
-        path_to_file = _result_path(outdir, data_info.dataset_name, data_info.transform_name, topic)
+        csv_file = _result_path(outdir, data_info.dataset_name, data_info.transform_name, topic)
         aggregator = ResultsAggregator(results_df)
         # put old results before new results -> prepend=True
-        aggregator.append_csv(path_to_file, prepend=True)
-        aggregator.save_as_csv(path_to_file)
+        aggregator.append_from_csv(csv_file, prepend=True)
+        aggregator.save_as_csv(csv_file)
         all_results.append_df(aggregator.results)
 
     return all_results.results

--- a/ethicml/visualisation/plot.py
+++ b/ethicml/visualisation/plot.py
@@ -186,20 +186,19 @@ def single_plot(
     Returns:
         the legend object if something was plotted; False otherwise
     """
-    results_df = results.data
-    mask_for_dataset = results_df.index.get_level_values("dataset") == dataset
+    mask_for_dataset = results.index.get_level_values("dataset") == dataset
     if transform is not None:
         transforms: List[str] = [transform]
     else:
-        transforms = [str(t) for t in results_df.index.to_frame()["transform"].unique()]
+        transforms = [str(t) for t in results.index.to_frame()["transform"].unique()]
 
     entries: List[DataEntry] = []
     count = 0
-    for model in results_df.index.to_frame()["model"].unique():
-        mask_for_model = results_df.index.get_level_values("model") == model
+    for model in results.index.to_frame()["model"].unique():
+        mask_for_model = results.index.get_level_values("model") == model
         for transform_ in transforms:
-            mask_for_transform = results_df.index.get_level_values("transform") == transform_
-            data = results_df.loc[mask_for_dataset & mask_for_model & mask_for_transform]
+            mask_for_transform = results.index.get_level_values("transform") == transform_
+            data = results.loc[mask_for_dataset & mask_for_model & mask_for_transform]
             if data[[xaxis[0], yaxis[0]]].empty or data[[xaxis[0], yaxis[0]]].isnull().any().any():
                 if not include_nan_entries:
                     continue  # this entry has missing values
@@ -250,10 +249,9 @@ def plot_results(
     """
     directory = Path(".") / "plots"
     directory.mkdir(exist_ok=True)
-    results_df = results.data
 
     def _get_columns(metric: Metric) -> List[str]:
-        cols = [col for col in results_df.columns if metric.name in col]
+        cols = [col for col in results.columns if metric.name in col]
         if not cols:
             raise ValueError(f'No matching columns found for Metric "{metric.name}".')
         # if there are multiple matches, then the metric was `per_sensitive_attribute`. In this
@@ -266,14 +264,14 @@ def plot_results(
         # if the metric is given as a Metric object, look for matching columns
         cols_x = _get_columns(metric_x)
     else:
-        if metric_x not in results_df.columns:
+        if metric_x not in results.columns:
             raise ValueError(f'No column named "{metric_x}".')
         cols_x = [metric_x]
 
     if isinstance(metric_y, Metric):
         cols_y = _get_columns(metric_y)
     else:
-        if metric_y not in results_df.columns:
+        if metric_y not in results.columns:
             raise ValueError(f'No column named "{metric_y}".')
         cols_y = [metric_y]
 
@@ -283,12 +281,12 @@ def plot_results(
 
     transforms: List[Optional[str]]
     if transforms_separately:
-        transforms = [str(t) for t in results_df.index.to_frame()["transform"].unique()]
+        transforms = [str(t) for t in results.index.to_frame()["transform"].unique()]
     else:
         transforms = [None]
 
     figure_list: List[Tuple[plt.Figure, plt.Axes]] = []
-    for dataset in results_df.index.to_frame()["dataset"].unique():
+    for dataset in results.index.to_frame()["dataset"].unique():
         dataset_: str = str(dataset)
         for transform in transforms:
             for x_axis, y_axis in possible_pairs:

--- a/run_pydocstyle.py
+++ b/run_pydocstyle.py
@@ -4,7 +4,7 @@ subprocess.call(
     [
         "pydocstyle",
         "--convention=google",
-        "--add-ignore=D105",
+        "--add-ignore=D105,D107",
         "--ignore-decorators=implements|overload",
         "--count",
         "-e",

--- a/tests/models_test/inprocess_test/cv_test.py
+++ b/tests/models_test/inprocess_test/cv_test.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, NamedTuple, Type, Union
+"""Tests for cross validation."""
+from typing import Dict, List, NamedTuple, Type, Union, Sequence
 
 import pytest
 
@@ -10,8 +11,10 @@ from ethicml.utility import Prediction, TrainTestPair
 
 
 class CvParam(NamedTuple):
+    """Specification of a unit test for cross validation."""
+
     model: Type[InAlgorithm]
-    hyperparams: Dict[str, Union[List[int], List[str]]]
+    hyperparams: Dict[str, Union[Sequence[float], List[str]]]
     num_pos: int
 
 
@@ -25,7 +28,7 @@ CV_PARAMS = [
 def test_cv(
     toy_train_test: TrainTestPair,
     model: Type[InAlgorithm],
-    hyperparams: Dict[str, Union[List[int], List[str]]],
+    hyperparams: Dict[str, Union[Sequence[float], List[str]]],
     num_pos: int,
 ):
     """test cv svm"""
@@ -46,7 +49,7 @@ def test_cv(
 def test_parallel_cv(
     toy_train_test: TrainTestPair,
     model: Type[InAlgorithm],
-    hyperparams: Dict[str, Union[List[int], List[str]]],
+    hyperparams: Dict[str, Union[Sequence[float], List[str]]],
     num_pos: int,
 ) -> None:
     """test parallel cv."""

--- a/tests/models_test/inprocess_test/models_inprocessing_test.py
+++ b/tests/models_test/inprocess_test/models_inprocessing_test.py
@@ -221,7 +221,7 @@ def test_threaded_agarwal():
             datasets=[toy()], inprocess_models=models, metrics=[AssertResult()], delete_prev=True
         )
     )
-    assert results.data["assert_result"].iloc[0] == 0.0
+    assert results["assert_result"].iloc[0] == 0.0
 
 
 def test_lr_prob(toy_train_test: TrainTestPair):

--- a/tests/visualisation_test.py
+++ b/tests/visualisation_test.py
@@ -53,9 +53,9 @@ def test_plot_evals():
         test_mode=True,
         delete_prev=True,
     )
-    assert results.data["seed"][0] == results.data["seed"][1] == results.data["seed"][2] == 0
-    assert results.data["seed"][3] == results.data["seed"][4] == results.data["seed"][5] == 2410
-    assert results.data["seed"][6] == results.data["seed"][7] == results.data["seed"][8] == 4820
+    assert results["seed"][0] == results["seed"][1] == results["seed"][2] == 0
+    assert results["seed"][3] == results["seed"][4] == results["seed"][5] == 2410
+    assert results["seed"][6] == results["seed"][7] == results["seed"][8] == 4820
 
     figs_and_plots: List[Tuple[plt.Figure, plt.Axes]]
 


### PR DESCRIPTION
It was getting annoying to always do `results.data` to access the
underlying dataframe. Now that Results is just a NewType wrapper around
DataFrame, you don't have to do this anymore. The price we pay for this
is that all the class methods have to be turned into normal functions
which is a bit ugly, but the "enduser" will likely never deal with them.
(The only place in the code where this comes up is in evaluate_models).