### PR TITLE
The .square() method is too new; fall back to .pow(2)

### DIFF
--- a/ethicml/implementations/dro_modules/dro_loss.py
+++ b/ethicml/implementations/dro_modules/dro_loss.py
@@ -22,4 +22,4 @@ class DROLoss(nn.Module):
 
     @implements(nn.Module)
     def forward(self, pred: Tensor, target: Tensor) -> Tensor:  # pylint: disable=arguments-differ
-        return (self.loss(pred, target) - self.eta).relu().square().mean()
+        return (self.loss(pred, target) - self.eta).relu().pow(2).mean()


### PR DESCRIPTION
I think `.square()` was added in pytorch 1.5.