### PR TITLE
Disable pylint errors already covered by mypy/pydocstyle

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install wheel
         pip install -e .[ci]
     - name: Test with pytest
       run: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -54,7 +54,17 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=bad-continuation,import-error,unsubscriptable-object,no-else-return
+disable=bad-continuation,
+        import-error,
+        unsubscriptable-object,
+        isinstance-second-argument-not-valid-type,
+        not-callable,
+        arguments-differ,
+        no-value-for-parameter,
+        no-else-return,
+        missing-module-docstring,
+        missing-class-docstring,
+        missing-function-docstring
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/ethicml/vision/data/dataset_wrappers.py
+++ b/ethicml/vision/data/dataset_wrappers.py
@@ -38,7 +38,7 @@ class DatasetWrapper(Dataset):
     @transform.setter
     def transform(self, transform: Optional[TransformType]) -> None:
         transform = transform or []
-        if not isinstance(transform, (Sequence)):
+        if not isinstance(transform, Sequence):
             transform = [transform]
         assert transform is not None
         self.__transform = transform

--- a/ethicml/visualisation/plot.py
+++ b/ethicml/visualisation/plot.py
@@ -25,9 +25,6 @@ def save_2d_plot(data: DataTuple, filepath: str) -> None:
     columns = data.x.columns
 
     amalgamated = pd.concat([data.x, data.s, data.y], axis="columns")
-    curr = mpl.get_backend()
-    print(curr)
-    mpl.use("agg")
 
     plot = sns.scatterplot(
         x=columns[0],

--- a/ethicml/visualisation/plot.py
+++ b/ethicml/visualisation/plot.py
@@ -25,6 +25,9 @@ def save_2d_plot(data: DataTuple, filepath: str) -> None:
     columns = data.x.columns
 
     amalgamated = pd.concat([data.x, data.s, data.y], axis="columns")
+    curr = mpl.get_backend()
+    print(curr)
+    mpl.use("agg")
 
     plot = sns.scatterplot(
         x=columns[0],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'dataclasses;python_version<"3.7"',  # dataclasses are in the stdlib in python>=3.7
         "fairlearn >= 0.4.0",
         "GitPython >= 2.1.11",
-        "matplotlib >= 3.0.2",
+        "matplotlib >= 3.0.2, < 3.3.1",
         "numpy >= 1.14.2",
         "pandas >= 0.24.0",
         "pipenv >= 2018.11.26",


### PR DESCRIPTION
There is still plenty for pylint to complain about:

```
************* Module ethicml.metrics.cv
/Users/tk324/PycharmProjects/ethicml/ethicml/metrics/cv.py:   18, 8: Import outside toplevel (ethicml.evaluators.per_sensitive_attribute.metric_per_sensitive_attribute, ethicml.evaluators.per_sensitive_attribute.diff_per_sensitive_attribute) (import-outside-toplevel)
************* Module ethicml.metrics.dependence_measures
/Users/tk324/PycharmProjects/ethicml/ethicml/metrics/dependence_measures.py:   91,24: Variable name "l" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
************* Module ethicml.vision.data.transforms
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/transforms.py:   12, 4: Method could be a function (no-self-use)
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/transforms.py:   35, 0: Too few public methods (0/1) (too-few-public-methods)
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/transforms.py:   46, 0: Too few public methods (0/1) (too-few-public-methods)
************* Module ethicml.vision.data.label_dependent_transforms
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/label_dependent_transforms.py:  111, 0: Line too long (101/100) (line-too-long)
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/label_dependent_transforms.py:  145, 0: Line too long (102/100) (line-too-long)
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/label_dependent_transforms.py:   42, 0: Too few public methods (0/1) (too-few-public-methods)
************* Module ethicml.vision.data.image_dataset
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/image_dataset.py:  139, 2: FIXME: the following check should not be hard coded (fixme)
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/image_dataset.py:   94, 0: Too many arguments (11/10) (too-many-arguments)
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/image_dataset.py:  173, 0: Too many arguments (11/10) (too-many-arguments)
************* Module ethicml.vision.data.cmnist
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/cmnist.py:   68, 0: Line too long (101/100) (line-too-long)
************* Module ethicml.vision.data.dataset_wrappers
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/dataset_wrappers.py:   12, 0: Class name "_T_co" doesn't conform to PascalCase naming style (invalid-name)
************* Module ethicml.vision.data.genfaces
/Users/tk324/PycharmProjects/ethicml/ethicml/vision/data/genfaces.py:   84, 8: Import outside toplevel (zipfile) (import-outside-toplevel)
************* Module ethicml.evaluators.cross_validator
/Users/tk324/PycharmProjects/ethicml/ethicml/evaluators/cross_validator.py:  121, 2: TODO: this should also compute diffs and ratios (fixme)
************* Module ethicml.evaluators.evaluate_models
/Users/tk324/PycharmProjects/ethicml/ethicml/evaluators/evaluate_models.py:  252,24: Unused variable 'postprocess' (unused-variable)
************* Module ethicml.visualisation.plot
/Users/tk324/PycharmProjects/ethicml/ethicml/visualisation/plot.py:   60, 4: Import outside toplevel (imageio) (import-outside-toplevel)
/Users/tk324/PycharmProjects/ethicml/ethicml/visualisation/plot.py:  153, 0: Too many arguments (12/10) (too-many-arguments)
************* Module ethicml.implementations.pytorch_common
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/pytorch_common.py:  139, 4: Argument name "a" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/pytorch_common.py:  139, 4: Argument name "b" doesn't conform to snake_case naming style (invalid-name)
************* Module ethicml.implementations.zemel
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:  111, 0: Line too long (110/100) (line-too-long)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   18, 4: Class attribute name "Ax" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   19, 4: Class attribute name "Ay" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   20, 4: Class attribute name "Az" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   28, 0: Function name "LFR_optim_objective" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   28, 0: Argument name "A_x" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   28, 0: Argument name "A_y" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   28, 0: Argument name "A_z" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   28, 0: Too many arguments (11/10) (too-many-arguments)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   45, 4: Variable name "w" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   48, 4: Variable name "M_unprivileged" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   52, 4: Variable name "M_privileged" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   57, 4: Variable name "L_x" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   60, 4: Variable name "L_z" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   61, 4: Variable name "L_y" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   42, 4: Unused variable 'num_unprivileged' (unused-variable)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   43, 4: Unused variable 'num_privileged' (unused-variable)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   78, 0: Argument name "w" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:   82, 4: Variable name "M" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:  136, 4: Variable name "w" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:  105, 4: Unused variable 'num_train_samples' (unused-variable)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:  151, 0: Argument name "w" doesn't conform to snake_case naming style (invalid-name)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:  153,34: Unused variable 'labels_hat_nonsensitive' (unused-variable)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:  155,31: Unused variable 'labels_hat_sensitive' (unused-variable)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/zemel.py:  179, 4: String statement has no effect (pointless-string-statement)
************* Module ethicml.implementations.svm
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/svm.py:   13, 4: Class attribute name "c" doesn't conform to snake_case naming style (invalid-name)
************* Module ethicml.implementations.vfae_modules.utils
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/vfae_modules/utils.py:   52, 8: Unused variable 'z2' (unused-variable)
/Users/tk324/PycharmProjects/ethicml/ethicml/implementations/vfae_modules/utils.py:   53, 8: Unused variable 'z1_dec' (unused-variable)
************* Module ethicml.data.vision_data.celeba
/Users/tk324/PycharmProjects/ethicml/ethicml/data/vision_data/celeba.py:  150, 4: Import outside toplevel (torchvision.datasets.utils.check_integrity) (import-outside-toplevel)
/Users/tk324/PycharmProjects/ethicml/ethicml/data/vision_data/celeba.py:  166, 4: Import outside toplevel (zipfile) (import-outside-toplevel)
/Users/tk324/PycharmProjects/ethicml/ethicml/data/vision_data/celeba.py:  167, 4: Import outside toplevel (torchvision.datasets.utils.download_file_from_google_drive) (import-outside-toplevel)
************* Module ethicml.data.vision_data.genfaces
/Users/tk324/PycharmProjects/ethicml/ethicml/data/vision_data/genfaces.py:   83, 4: Import outside toplevel (zipfile) (import-outside-toplevel)
/Users/tk324/PycharmProjects/ethicml/ethicml/data/vision_data/genfaces.py:   84, 4: Import outside toplevel (torchvision.datasets.utils.download_file_from_google_drive) (import-outside-toplevel)
************* Module ethicml.data.tabular_data.adult
/Users/tk324/PycharmProjects/ethicml/ethicml/data/tabular_data/adult.py:  179, 2: TODO: this is currently broken. we'd need to take into account that race is one-hot (fixme)
************* Module ethicml.data.csvs.make_crime_from_raw
/Users/tk324/PycharmProjects/ethicml/ethicml/data/csvs/make_crime_from_raw.py:  173, 0: Line too long (117/100) (line-too-long)
/Users/tk324/PycharmProjects/ethicml/ethicml/data/csvs/make_crime_from_raw.py:  188, 0: Unnecessary use of a comprehension (unnecessary-comprehension)
************* Module ethicml.utility.data_helpers
/Users/tk324/PycharmProjects/ethicml/ethicml/utility/data_helpers.py:    1, 0: Similar lines in 3 files
==ethicml.data.csvs.make_crime_from_raw:60
==ethicml.data.tabular_data.crime:190
==ethicml.data.tabular_data.crime:39
            "HispPerCap",
```