### PR TITLE
Import everything in ethicml into one namespace

### DIFF
--- a/ethicml/__init__.py
+++ b/ethicml/__init__.py
@@ -1,2 +1,9 @@
 """EthicML."""
-from . import algorithms, common, data, evaluators, metrics, preprocessing, utility, visualisation
+from .algorithms import *
+from .common import *
+from .data import *
+from .evaluators import *
+from .metrics import *
+from .preprocessing import *
+from .utility import *
+from .visualisation import *

--- a/ethicml/algorithms/preprocess/__init__.py
+++ b/ethicml/algorithms/preprocess/__init__.py
@@ -1,7 +1,7 @@
 """Pre-process algorithms take the training data and transform it."""
-from .beutel import Beutel
-from .calders import Calders
-from .pre_algorithm import PreAlgorithm, PreAlgorithmAsync
-from .upsampler import Upsampler
-from .vfae import VFAE
-from .zemel import Zemel
+from .beutel import *
+from .calders import *
+from .pre_algorithm import *
+from .upsampler import *
+from .vfae import *
+from .zemel import *

--- a/ethicml/algorithms/preprocess/beutel.py
+++ b/ethicml/algorithms/preprocess/beutel.py
@@ -7,6 +7,8 @@ from ethicml.utility import FairnessType
 from .interface import flag_interface
 from .pre_algorithm import PreAlgorithmAsync
 
+__all__ = ["Beutel"]
+
 
 class Beutel(PreAlgorithmAsync):
     """Beutel's adversarially learned fair representations."""

--- a/ethicml/algorithms/preprocess/calders.py
+++ b/ethicml/algorithms/preprocess/calders.py
@@ -7,6 +7,8 @@ from ethicml.utility import DataTuple, SoftPrediction, TestTuple, concat_dt
 
 from .pre_algorithm import PreAlgorithm
 
+__all__ = ["Calders"]
+
 
 class Calders(PreAlgorithm):
     """Massaging algorithm from Kamiran&Calders 2012."""

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -9,6 +9,8 @@ from ethicml.algorithms.algorithm_base import Algorithm, AlgorithmAsync, run_blo
 from ethicml.common import implements
 from ethicml.utility import DataTuple, TestTuple
 
+__all__ = ["PreAlgorithm", "PreAlgorithmAsync"]
+
 
 class PreAlgorithm(Algorithm):
     """Abstract Base Class for all algorithms that do pre-processing."""

--- a/ethicml/algorithms/preprocess/upsampler.py
+++ b/ethicml/algorithms/preprocess/upsampler.py
@@ -11,6 +11,8 @@ from ethicml.utility import DataTuple, SoftPrediction, TestTuple
 
 from .pre_algorithm import PreAlgorithm
 
+__all__ = ["Upsampler"]
+
 
 class Upsampler(PreAlgorithm):
     """Upsampler algorithm.

--- a/ethicml/algorithms/preprocess/vfae.py
+++ b/ethicml/algorithms/preprocess/vfae.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Optional, Union
 from .interface import flag_interface
 from .pre_algorithm import PreAlgorithmAsync
 
+__all__ = ["VFAE"]
+
 
 class VFAE(PreAlgorithmAsync):
     """VFAE Object - see implementation file for details."""

--- a/ethicml/algorithms/preprocess/zemel.py
+++ b/ethicml/algorithms/preprocess/zemel.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Union
 from .interface import flag_interface
 from .pre_algorithm import PreAlgorithmAsync
 
+__all__ = ["Zemel"]
+
 
 class Zemel(PreAlgorithmAsync):
     """AIF360 implementation of Zemel's LFR."""

--- a/ethicml/utility/__init__.py
+++ b/ethicml/utility/__init__.py
@@ -1,6 +1,6 @@
 """This module contains kind of useful things that don't really belong anywhere else (just yet)."""
 
-from .activation import Activation
+from .activation import *
 from .data_helpers import *
 from .data_structures import *
-from .heaviside import Heaviside
+from .heaviside import *

--- a/ethicml/utility/activation.py
+++ b/ethicml/utility/activation.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 
 import numpy
 
+__all__ = ["Activation"]
+
 
 class Activation(ABC):
     """Base class for decision functions."""

--- a/ethicml/utility/heaviside.py
+++ b/ethicml/utility/heaviside.py
@@ -4,6 +4,8 @@ import numpy
 
 from .activation import Activation
 
+__all__ = ["Heaviside"]
+
 
 class Heaviside(Activation):
     """Decision function that accepts predictions with score of 50% or above."""


### PR DESCRIPTION
Is there a reason not to do this?

(`ethicml.implementations` and `ethicml.vision` are of course not automatically imported, because they require pytorch.)