### PR TITLE
Remove pillow version and fix version number on master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ from setuptools import find_packages, setup
 # We follow Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = "0"
 _MINOR_VERSION = "1"
-_PATCH_VERSION = "0"
+_PATCH_VERSION = "1"
 
-_VERSION_SUFFIX = "dev"
+_VERSION_SUFFIX = "dev1"
 
 # Example, '0.4.0-rc1'
 version = ".".join([_MAJOR_VERSION, _MINOR_VERSION, _PATCH_VERSION])
@@ -37,7 +37,7 @@ setup(
         "numpy >= 1.14.2",
         "pandas >= 0.24.0",
         "pipenv >= 2018.11.26",
-        "pillow >= 7.1",
+        "pillow",
         "scikit_learn >= 0.20.1",
         "seaborn >= 0.9.0",
         "tqdm >= 4.31.1",
@@ -45,7 +45,7 @@ setup(
         "typing-extensions >= 3.7.2",
     ],
     extras_require={
-        "ci": ["pytest >= 3.3.2", "pytest-cov >= 2.6.0", "torch == 1.5.0", "torchvision == 0.6.0",],
+        "ci": ["pytest >= 3.3.2", "pytest-cov >= 2.6.0", "torch == 1.5.0", "torchvision == 0.6.0"],
         # use `pip install EthicML[dev]` to install development packages
         "dev": [
             "black",


### PR DESCRIPTION
The pillow dependency was only there because one version of pytorch had a problem with pillow 7.0. But this is not the case anymore, so we're not requiring any specific version of pillow.