### PR TITLE
Remove dependency on pillow entirely

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "numpy >= 1.14.2",
         "pandas >= 0.24.0",
         "pipenv >= 2018.11.26",
-        "pillow",
         "scikit_learn >= 0.20.1",
         "seaborn >= 0.9.0",
         "tqdm >= 4.31.1",


### PR DESCRIPTION
`PIL` is only imported in those files where `torchvision` is also imported (aka `ethicml/vision/data/image_dataset.py`). As torchvision requires PIL, we should be fine.