### PR TITLE
Write tests to simulate the case where no pytorch is available

### DIFF
--- a/ethicml/common.py
+++ b/ethicml/common.py
@@ -1,10 +1,14 @@
 """Common variables / constants that make things run smoother."""
 
+import importlib
 import os
 from pathlib import Path
 from typing import Any, Callable, Type, TypeVar
 
-__all__ = ["ROOT_DIR", "ROOT_PATH", "implements"]
+__all__ = ["TORCH_AVAILABLE", "TORCHVISION_AVAILABLE", "ROOT_DIR", "ROOT_PATH", "implements"]
+
+TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
+TORCHVISION_AVAILABLE = importlib.util.find_spec("torchvision") is not None
 
 ROOT_DIR: str = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
 ROOT_PATH: Path = Path(__file__).parent.resolve()

--- a/ethicml/data/vision_data/celeba.py
+++ b/ethicml/data/vision_data/celeba.py
@@ -4,8 +4,9 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from typing_extensions import Final, Literal
 
+from ethicml import common
 from ..dataset import Dataset
-from ..util import LabelSpec, PartialLabelSpec, flatten_dict, label_specs_to_feature_list
+from ..util import PartialLabelSpec, flatten_dict, label_specs_to_feature_list
 
 __all__ = ["CelebAttrs", "celeba"]
 
@@ -157,6 +158,8 @@ def celeba(
 
 
 def _check_integrity(base: Path) -> bool:
+    if not common.TORCHVISION_AVAILABLE:
+        raise RuntimeError("Need torchvision to download data.")
     from torchvision.datasets.utils import check_integrity
 
     for (_, md5, filename) in _FILE_LIST:
@@ -173,6 +176,8 @@ def _check_integrity(base: Path) -> bool:
 
 def _download(base: Path) -> None:
     """Attempt to download data if files cannot be found in the base folder."""
+    if not common.TORCHVISION_AVAILABLE:
+        raise RuntimeError("Need torchvision to download data.")
     import zipfile
     from torchvision.datasets.utils import download_file_from_google_drive
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from typing import Generator
 import pandas as pd
 import pytest
 
+import ethicml
 from ethicml.common import ROOT_PATH
 from ethicml.data import load_data, toy
 from ethicml.preprocessing import train_test_split
@@ -86,3 +87,18 @@ def temp_dir() -> Generator[Path, None, None]:
 def get_id(value):
     """Get ID."""
     return getattr(value, "name", value)
+
+
+@pytest.fixture(scope="function")
+def simulate_no_torch() -> Generator[None, None, None]:
+    # ======= set up ========
+    torch_available = ethicml.common.TORCH_AVAILABLE
+    torchvision_available = ethicml.common.TORCHVISION_AVAILABLE
+    ethicml.common.TORCH_AVAILABLE = False
+    ethicml.common.TORCHVISION_AVAILABLE = False
+
+    yield  # run test
+
+    # ====== tear down =======
+    ethicml.common.TORCH_AVAILABLE = torch_available
+    ethicml.common.TORCHVISION_AVAILABLE = torchvision_available

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import Generator
 import pandas as pd
 import pytest
 
-import ethicml
+import ethicml as em
 from ethicml.common import ROOT_PATH
 from ethicml.data import load_data, toy
 from ethicml.preprocessing import train_test_split
@@ -92,13 +92,13 @@ def get_id(value):
 @pytest.fixture(scope="function")
 def simulate_no_torch() -> Generator[None, None, None]:
     # ======= set up ========
-    torch_available = ethicml.common.TORCH_AVAILABLE
-    torchvision_available = ethicml.common.TORCHVISION_AVAILABLE
-    ethicml.common.TORCH_AVAILABLE = False
-    ethicml.common.TORCHVISION_AVAILABLE = False
+    torch_available = em.common.TORCH_AVAILABLE
+    torchvision_available = em.common.TORCHVISION_AVAILABLE
+    em.common.TORCH_AVAILABLE = False
+    em.common.TORCHVISION_AVAILABLE = False
 
     yield  # run test
 
     # ====== tear down =======
-    ethicml.common.TORCH_AVAILABLE = torch_available
-    ethicml.common.TORCHVISION_AVAILABLE = torchvision_available
+    em.common.TORCH_AVAILABLE = torch_available
+    em.common.TORCHVISION_AVAILABLE = torchvision_available

--- a/tests/loading_data_test.py
+++ b/tests/loading_data_test.py
@@ -438,6 +438,13 @@ def test_celeba_multi_s():
     assert data.x["filename"].iloc[0] == "000001.jpg"
 
 
+@pytest.mark.usefixtures("simulate_no_torch")
+def test_celeba_no_torch():
+    """Test celeba."""
+    with pytest.raises(RuntimeError, match="Need torchvision to download data."):
+        celeba(download_dir="some_dir", download=True)
+
+
 def test_genfaces():
     """Test genfaces."""
     gen_faces, _ = genfaces(download_dir="non-existent")


### PR DESCRIPTION
This turned out to be a bit tricky. It seems the best way to do this is to have a central point that checks if torch can be imported and which then sets a global variable. Then, in the tests we can manipulate that variable to make the code think that torch is not installed.