### PR TITLE
Don't use type stubs from data-scienc-types anymore

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -89,7 +89,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install mypy
         pip install git+https://github.com/predictive-analytics-lab/python-type-stubs.git
-        pip install typed-argument-parser==1.4 teext numpy
+        pip install typed-argument-parser==1.4 teext numpy>=1.20.1
     - name: Type check with mypy
       run: |
         python run_mypy.py

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -88,8 +88,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install mypy
-        pip install git+https://github.com/predictive-analytics-lab/data-science-types
-        pip install typed-argument-parser==1.4 teext
+        pip install git+https://github.com/predictive-analytics-lab/python-type-stubs.git
+        pip install typed-argument-parser==1.4 teext numpy
     - name: Type check with mypy
       run: |
         python run_mypy.py

--- a/ethicml/algorithms/postprocess/hardt.py
+++ b/ethicml/algorithms/postprocess/hardt.py
@@ -66,7 +66,7 @@ class Hardt(PostAlgorithm):
         # b_ub: 1-D array of values representing the upper-bound of each
         # inequality constraint (row) in A_ub.
         # Just to keep these between zero and one
-        inequalilty_constraint_matrix: np.ndarray[np.float64] = np.array(
+        inequalilty_constraint_matrix: np.ndarray = np.array(
             [
                 [1.0, 0.0, 0.0, 0.0],
                 [-1.0, 0.0, 0.0, 0.0],
@@ -79,7 +79,7 @@ class Hardt(PostAlgorithm):
             ],
             dtype=np.float64,
         )
-        b_ub: np.ndarray[np.float64] = np.array(
+        b_ub: np.ndarray = np.array(
             [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0], dtype=np.float64
         )
 

--- a/ethicml/algorithms/postprocess/hardt.py
+++ b/ethicml/algorithms/postprocess/hardt.py
@@ -79,9 +79,7 @@ class Hardt(PostAlgorithm):
             ],
             dtype=np.float64,
         )
-        b_ub: np.ndarray = np.array(
-            [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0], dtype=np.float64
-        )
+        b_ub: np.ndarray = np.array([1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0], dtype=np.float64)
 
         # Create boolean conditioning vectors for protected groups
         mask_s1 = train.s[train.s.columns[0]].to_numpy() == 1

--- a/ethicml/data/dataset.py
+++ b/ethicml/data/dataset.py
@@ -214,7 +214,7 @@ class Dataset:
             return attributes, mask
 
         # create a Series of zeroes with the same length as the dataframe
-        combination: pd.Series[int] = pd.Series(0, index=range(len(attributes)))
+        combination: pd.Series = pd.Series(0, index=range(len(attributes)))
 
         for name, spec in label_mapping.items():
             if len(spec.columns) > 1:  # data is one-hot encoded

--- a/ethicml/implementations/pytorch_common.py
+++ b/ethicml/implementations/pytorch_common.py
@@ -16,13 +16,13 @@ if TYPE_CHECKING:
 def _get_info(
     data: TestTuple,
 ) -> Tuple[
-    "np.ndarray[np.float32]",
-    "np.ndarray[np.float32]",
+    np.ndarray,
+    np.ndarray,
     int,
     int,
     int,
-    "pd.Index[str]",
-    "pd.Index[str]",
+    pd.Index,
+    pd.Index,
 ]:
     features = data.x.to_numpy(dtype=np.float32)
     sens_labels = data.s.to_numpy(dtype=np.float32)

--- a/ethicml/implementations/pytorch_common.py
+++ b/ethicml/implementations/pytorch_common.py
@@ -1,16 +1,14 @@
 """Functions that are common to PyTorch models."""
-from typing import TYPE_CHECKING, Tuple
+from typing import Tuple
 
 import numpy as np
+import pandas as pd
 import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.utils.data import Dataset
 
 from ethicml.utility import DataTuple, TestTuple
-
-if TYPE_CHECKING:
-    import pandas as pd  # only needed for type checking
 
 
 def _get_info(data: TestTuple) -> Tuple[np.ndarray, np.ndarray, int, int, int, pd.Index, pd.Index]:
@@ -40,7 +38,7 @@ class TestDataset(Dataset):
         return self.num
 
     @property
-    def names(self) -> Tuple["pd.Index[str]", "pd.Index[str]"]:
+    def names(self) -> Tuple[pd.Index, pd.Index]:
         """Get tuple of x names and s names."""
         return self.x_names, self.s_names
 
@@ -65,7 +63,7 @@ class CustomDataset(Dataset):
         return self.num
 
     @property
-    def names(self) -> Tuple["pd.Index[str]", "pd.Index[str]", "pd.Index[str]"]:
+    def names(self) -> Tuple[pd.Index, pd.Index, pd.Index]:
         """Get tuple of x names, s names and y names."""
         return self.x_names, self.s_names, self.y_names
 

--- a/ethicml/implementations/pytorch_common.py
+++ b/ethicml/implementations/pytorch_common.py
@@ -13,17 +13,7 @@ if TYPE_CHECKING:
     import pandas as pd  # only needed for type checking
 
 
-def _get_info(
-    data: TestTuple,
-) -> Tuple[
-    np.ndarray,
-    np.ndarray,
-    int,
-    int,
-    int,
-    pd.Index,
-    pd.Index,
-]:
+def _get_info(data: TestTuple) -> Tuple[np.ndarray, np.ndarray, int, int, int, pd.Index, pd.Index]:
     features = data.x.to_numpy(dtype=np.float32)
     sens_labels = data.s.to_numpy(dtype=np.float32)
     num = data.s.shape[0]

--- a/ethicml/implementations/zemel.py
+++ b/ethicml/implementations/zemel.py
@@ -37,7 +37,7 @@ def LFR_optim_objective(
     A_z: float,
     print_interval,
     verbose,
-) -> float:
+) -> np.number:
     """LFR optim objective."""
     num_unprivileged, features_dim = x_unprivileged.shape
     num_privileged, _ = x_privileged.shape

--- a/ethicml/metrics/confusion_matrix.py
+++ b/ethicml/metrics/confusion_matrix.py
@@ -16,8 +16,8 @@ def confusion_matrix(
     prediction: Prediction, actual: DataTuple, pos_cls: int
 ) -> Tuple[int, int, int, int]:
     """Apply sci-kit learn's confusion matrix."""
-    actual_y: np.ndarray[np.int32] = actual.y.to_numpy(dtype=np.int32)
-    labels: np.ndarray[np.int32] = np.unique(actual_y)
+    actual_y: np.ndarray = actual.y.to_numpy(dtype=np.int32)
+    labels: np.ndarray = np.unique(actual_y)
     if labels.size == 1:
         labels = np.array([0, 1], dtype=np.int32)
     conf_matr: np.ndarray = conf_mtx(y_true=actual_y, y_pred=prediction.hard, labels=labels)

--- a/ethicml/metrics/dependence_measures.py
+++ b/ethicml/metrics/dependence_measures.py
@@ -144,6 +144,6 @@ class RenyiCorrelation(_DependenceMeasure):
         return singulars[1]
 
 
-def _count_true(mask: "np.ndarray[np.bool_]") -> int:
+def _count_true(mask: np.ndarray) -> int:
     """Count the number of elements that are True."""
     return mask.nonzero()[0].shape[0]

--- a/ethicml/metrics/hsic.py
+++ b/ethicml/metrics/hsic.py
@@ -92,7 +92,7 @@ class Hsic(Metric):
 
             start += batchs_size
 
-        return np.mean(np.array(batches))
+        return np.array(batches).mean().item()
 
     @property
     def apply_per_sensitive(self) -> bool:

--- a/ethicml/metrics/prob_outcome.py
+++ b/ethicml/metrics/prob_outcome.py
@@ -15,4 +15,4 @@ class ProbOutcome(Metric):
     def score(self, prediction: Prediction, actual: DataTuple) -> float:
         if not isinstance(prediction, SoftPrediction):
             return float("nan")  # this metric only makes sense with probs
-        return prediction.soft.to_numpy().sum() / prediction.hard.size
+        return (prediction.soft.to_numpy().sum() / prediction.hard.size).item()

--- a/ethicml/preprocessing/adjust_labels.py
+++ b/ethicml/preprocessing/adjust_labels.py
@@ -30,8 +30,8 @@ class LabelBinarizer:
         # make copy of dataset
         dataset = dataset.replace(y=dataset.y.copy())
 
-        self.min_val = dataset.y.to_numpy().min()
-        self.max_val = dataset.y.to_numpy().max()
+        self.min_val = dataset.y.to_numpy().min().item()
+        self.max_val = dataset.y.to_numpy().max().item()
 
         y_col = dataset.y.columns[0]
 

--- a/ethicml/preprocessing/train_test_split.py
+++ b/ethicml/preprocessing/train_test_split.py
@@ -164,7 +164,7 @@ class RandomSplit(DataSplitter):
 
 def generate_proportional_split_indexes(
     data: DataTuple, train_percentage: float, random_seed: int = 42
-) -> Tuple["np.ndarray[np.int64]", "np.ndarray[np.int64]"]:
+) -> Tuple[np.ndarray, np.ndarray]:
     """Generate the indexes of the train and test splits using a proportional sampling scheme."""
     # local random state that won't affect the global state
     random = RandomState(seed=random_seed)
@@ -175,8 +175,8 @@ def generate_proportional_split_indexes(
     s_vals: List[int] = list(map(int, data.s[s_col].unique()))
     y_vals: List[int] = list(map(int, data.y[y_col].unique()))
 
-    train_indexes: List[np.ndarray[np.int64]] = []
-    test_indexes: List[np.ndarray[np.int64]] = []
+    train_indexes: List[np.ndarray] = []
+    test_indexes: List[np.ndarray] = []
 
     # iterate over all combinations of s and y
     for s, y in itertools.product(s_vals, y_vals):
@@ -270,8 +270,8 @@ class BalancedTestSplit(RandomSplit):
         s_vals: List[int] = list(map(int, data.s[s_col].unique()))
         y_vals: List[int] = list(map(int, data.y[y_col].unique()))
 
-        train_indexes: List[np.ndarray[np.int64]] = []
-        test_indexes: List[np.ndarray[np.int64]] = []
+        train_indexes: List[np.ndarray] = []
+        test_indexes: List[np.ndarray] = []
 
         num_test: Dict[Tuple[int, int], int] = {}
         # find out how many samples are available for the test set
@@ -339,15 +339,15 @@ class BalancedTestSplit(RandomSplit):
 
 def fold_data(data: DataTuple, folds: int) -> Iterator[Tuple[DataTuple, DataTuple]]:
     """So much love to sklearn for making their source code open."""
-    indices: np.ndarray[np.int64] = np.arange(data.x.shape[0])
+    indices: np.ndarray = np.arange(data.x.shape[0])
 
-    fold_sizes: np.ndarray[np.int32] = np.full(folds, data.x.shape[0] // folds, dtype=np.int32)
+    fold_sizes: np.ndarray = np.full(folds, data.x.shape[0] // folds, dtype=np.int32)
     fold_sizes[: data.x.shape[0] % folds] += np.int32(1)
 
     current = 0
     for i, fold_size in enumerate(fold_sizes):
         start, stop = current, int(current + fold_size)
-        val_inds: np.ndarray[np.int64] = indices[start:stop]
+        val_inds: np.ndarray = indices[start:stop]
         train_inds = np.array([i for i in indices if i not in val_inds])  # probably inefficient
 
         train_x = data.x.iloc[train_inds].reset_index(drop=True)

--- a/ethicml/vision/data/cmnist.py
+++ b/ethicml/vision/data/cmnist.py
@@ -26,7 +26,7 @@ _Classes = Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 
 def _filter_classes(dataset: MNIST, classes_to_keep: Sequence[int]) -> Subset:
-    targets: np.ndarray[np.int64] = dataset.targets.numpy()
+    targets: np.ndarray = dataset.targets.numpy()
     final_mask = np.zeros_like(targets, dtype=np.bool_)
     for index, label in enumerate(classes_to_keep):
         mask = targets == label

--- a/ethicml/vision/data/image_dataset.py
+++ b/ethicml/vision/data/image_dataset.py
@@ -52,7 +52,7 @@ class TorchImageDataset(VisionDataset):
         self.s_dim = 1
         y = data.y
 
-        self.x: np.ndarray[np.str_] = data.x["filename"].to_numpy()
+        self.x: np.ndarray = data.x["filename"].to_numpy()
         self.s = torch.as_tensor(s.to_numpy())
         self.y = torch.as_tensor(y.to_numpy())
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -39,6 +39,9 @@ ignore_missing_imports = True
 [mypy-imageio]
 ignore_missing_imports = True
 
+[mypy-matplotlib]
+ignore_missing_imports = True
+
 [mypy-PIL]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -39,7 +39,10 @@ ignore_missing_imports = True
 [mypy-imageio]
 ignore_missing_imports = True
 
-[mypy-matplotlib]
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-pandas.testing]
 ignore_missing_imports = True
 
 [mypy-PIL]

--- a/run_mypy_tests.py
+++ b/run_mypy_tests.py
@@ -4,7 +4,7 @@ import sys
 
 from mypy import api as mypy
 
-MAX_ALLOWED_ERRORS = 15
+MAX_ALLOWED_ERRORS = 25
 
 # Also check types on the tests
 RESULTS = mypy.run(["./tests/"])

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'dataclasses;python_version<"3.7"',  # dataclasses are in the stdlib in python>=3.7
         "GitPython >= 2.1.11",
         "matplotlib >= 3.0.2, < 3.3.1",
-        "numpy >= 1.20.1",
+        "numpy >= 1.14.2",
         "pandas >= 1.0",
         "pipenv >= 2018.11.26",
         "pillow",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'dataclasses;python_version<"3.7"',  # dataclasses are in the stdlib in python>=3.7
         "GitPython >= 2.1.11",
         "matplotlib >= 3.0.2, < 3.3.1",
-        "numpy >= 1.14.2",
+        "numpy >= 1.20.1",
         "pandas >= 1.0",
         "pipenv >= 2018.11.26",
         "pillow",

--- a/tests/run_algorithm_test.py
+++ b/tests/run_algorithm_test.py
@@ -12,7 +12,7 @@ import pytest
 import ethicml as em
 
 
-def count_true(mask: "np.ndarray[np.bool_]") -> int:
+def count_true(mask: np.ndarray) -> int:
     """Count the number of elements that are True"""
     return mask.nonzero()[0].shape[0]
 

--- a/tests/saving_data_test.py
+++ b/tests/saving_data_test.py
@@ -63,7 +63,7 @@ def test_predictions_info_loaded(temp_dir) -> None:
 
 def test_predictions_info_loaded_bad(temp_dir) -> None:
     """Test that predictions can be saved and loaded."""
-    preds = Prediction(hard=pd.Series([1]), info={"sample": np.array([1, 2, 3])})
+    preds = Prediction(hard=pd.Series([1]), info={"sample": np.array([1, 2, 3])})  # type: ignore
     with pytest.raises(AssertionError):
         preds.to_npz(temp_dir / "test.npz")
 


### PR DESCRIPTION
Instead we use the pandas type stubs from https://github.com/microsoft/python-type-stubs and the numpy type stubs that are now directly integrated in numpy.