### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install pylint
@@ -57,19 +57,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install black
       run: |
         python -m pip install --upgrade pip
         pip install black isort
     - name: Format with black
       run: |
-        python -m black --check -l 100 -t py36 -S ethicml/
-        python -m black --check -l 100 -t py36 -S tests/
+        python -m black --check -l 100 -t py37 -S ethicml/
+        python -m black --check -l 100 -t py37 -S tests/
     - name: Format with isort
       run: |
         isort . --check --diff
@@ -79,9 +79,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install mypy
@@ -100,9 +100,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install pydocstyle

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -89,7 +89,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install mypy
         pip install git+https://github.com/predictive-analytics-lab/python-type-stubs.git
-        pip install typed-argument-parser==1.4 teext numpy>=1.20.1
+        pip install typed-argument-parser==1.4 teext numpy>=1.20.1 palkit
     - name: Type check with mypy
       run: |
         python run_mypy.py

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Where appropriate, we even subsume some of these libraries.
 
 ## Installation
 
-EthicML requires Python >= 3.6.
+EthicML requires Python >= 3.7.
 To install EthicML, just do
 ```
 pip3 install ethicml

--- a/ethicml/algorithms/inprocess/blind.py
+++ b/ethicml/algorithms/inprocess/blind.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import pandas as pd
+from kit import implements
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 from .in_algorithm import InAlgorithm

--- a/ethicml/algorithms/inprocess/fairness_wo_demographics.py
+++ b/ethicml/algorithms/inprocess/fairness_wo_demographics.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-from ethicml.common import implements
+from kit import implements
 
 from .in_algorithm import InAlgorithmAsync
 from .shared import flag_interface

--- a/ethicml/algorithms/inprocess/in_algorithm.py
+++ b/ethicml/algorithms/inprocess/in_algorithm.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List
 
+from kit import implements
+
 from ethicml.algorithms.algorithm_base import Algorithm, AlgorithmAsync, run_blocking
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 __all__ = ["InAlgorithm", "InAlgorithmAsync"]

--- a/ethicml/algorithms/inprocess/kamiran.py
+++ b/ethicml/algorithms/inprocess/kamiran.py
@@ -3,9 +3,9 @@ from typing import Optional, Tuple
 
 import numpy as np
 import pandas as pd
+from kit import implements
 from sklearn.linear_model import LogisticRegression
 
-from ethicml.common import implements
 from ethicml.utility import ClassifierType, DataTuple, Prediction, TestTuple
 
 from .in_algorithm import InAlgorithm

--- a/ethicml/algorithms/inprocess/kamishima.py
+++ b/ethicml/algorithms/inprocess/kamishima.py
@@ -5,8 +5,8 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
+from kit import implements
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 from .in_algorithm import InAlgorithmAsync

--- a/ethicml/algorithms/inprocess/logistic_regression.py
+++ b/ethicml/algorithms/inprocess/logistic_regression.py
@@ -3,10 +3,10 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+from kit import implements
 from sklearn.linear_model import LogisticRegression, LogisticRegressionCV
 from sklearn.model_selection import KFold
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction, SoftPrediction, TestTuple
 
 from .in_algorithm import InAlgorithm

--- a/ethicml/algorithms/inprocess/majority.py
+++ b/ethicml/algorithms/inprocess/majority.py
@@ -1,8 +1,8 @@
 """Simply returns the majority label from the train set."""
 
 import pandas as pd
+from kit import implements
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 from .in_algorithm import InAlgorithm

--- a/ethicml/algorithms/inprocess/manual.py
+++ b/ethicml/algorithms/inprocess/manual.py
@@ -1,8 +1,8 @@
 """Manually specified (i.e. not learned) models."""
 import numpy as np
 import pandas as pd
+from kit import implements
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 from .in_algorithm import InAlgorithm

--- a/ethicml/algorithms/inprocess/mlp.py
+++ b/ethicml/algorithms/inprocess/mlp.py
@@ -2,9 +2,9 @@
 from typing import Dict, Optional, Tuple
 
 import pandas as pd
+from kit import implements
 from sklearn.neural_network import MLPClassifier
 
-from ethicml.common import implements
 from ethicml.utility import ActivationType, DataTuple, Prediction, TestTuple
 
 from .in_algorithm import InAlgorithm

--- a/ethicml/algorithms/inprocess/oracle.py
+++ b/ethicml/algorithms/inprocess/oracle.py
@@ -1,5 +1,7 @@
 """How would a perfect predictor perform?"""
-from ethicml import DataTuple, InAlgorithm, Prediction, TestTuple, implements
+from kit import implements
+
+from ethicml import DataTuple, InAlgorithm, Prediction, TestTuple
 from ethicml.algorithms.postprocess.dp_flip import DPFlip
 
 

--- a/ethicml/algorithms/inprocess/svm.py
+++ b/ethicml/algorithms/inprocess/svm.py
@@ -2,9 +2,9 @@
 from typing import Optional, Union
 
 import pandas as pd
+from kit import implements
 from sklearn.svm import SVC, LinearSVC
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 from .in_algorithm import InAlgorithm

--- a/ethicml/algorithms/postprocess/dp_flip.py
+++ b/ethicml/algorithms/postprocess/dp_flip.py
@@ -2,8 +2,9 @@
 from typing import Tuple
 
 import numpy as np
+from kit import implements
 
-from ethicml import DataTuple, PostAlgorithm, Prediction, TestTuple, implements
+from ethicml import DataTuple, PostAlgorithm, Prediction, TestTuple
 
 
 class DPFlip(PostAlgorithm):

--- a/ethicml/algorithms/postprocess/hardt.py
+++ b/ethicml/algorithms/postprocess/hardt.py
@@ -1,10 +1,10 @@
 """Post-processing method by Hardt et al."""
 import numpy as np
 import pandas as pd
+from kit import implements
 from numpy.random import RandomState
 from scipy.optimize import OptimizeResult, linprog
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 from .post_algorithm import PostAlgorithm

--- a/ethicml/algorithms/preprocess/calders.py
+++ b/ethicml/algorithms/preprocess/calders.py
@@ -1,7 +1,8 @@
 """Kamiran&Calders 2012, massaging."""
 from typing import Dict, List, Tuple
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, SoftPrediction, TestTuple, concat_dt
 
 from ..inprocess.logistic_regression import LRProb

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Tuple
 
+from kit import implements
+
 from ethicml.algorithms.algorithm_base import Algorithm, AlgorithmAsync, run_blocking
-from ethicml.common import implements
 from ethicml.utility import DataTuple, TestTuple
 
 __all__ = ["PreAlgorithm", "PreAlgorithmAsync"]

--- a/ethicml/algorithms/preprocess/upsampler.py
+++ b/ethicml/algorithms/preprocess/upsampler.py
@@ -3,9 +3,9 @@ import itertools
 from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
+from kit import implements
 from typing_extensions import Literal
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, SoftPrediction, TestTuple
 
 from ..inprocess.logistic_regression import LRProb

--- a/ethicml/common.py
+++ b/ethicml/common.py
@@ -2,7 +2,6 @@
 import os
 from importlib import util
 from pathlib import Path
-from typing import Any, Callable, TypeVar
 
 __all__ = ["TORCH_AVAILABLE", "TORCHVISION_AVAILABLE", "ROOT_DIR", "ROOT_PATH", "implements"]
 
@@ -11,25 +10,3 @@ TORCHVISION_AVAILABLE = util.find_spec("torchvision") is not None
 
 ROOT_DIR: str = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
 ROOT_PATH: Path = Path(__file__).parent.resolve()
-
-_F = TypeVar("_F", bound=Callable[..., Any])
-
-
-class implements:  # pylint: disable=invalid-name
-    """Mark a function as implementing an interface."""
-
-    def __init__(self, interface: type):
-        """Instantiate the decorator.
-
-        Args:
-            interface: the interface that is implemented
-        """
-        self.interface = interface
-
-    def __call__(self, func: _F) -> _F:
-        """Take a function and return it unchanged."""
-        super_method = getattr(self.interface, func.__name__, None)
-        assert super_method is not None, f"'{func.__name__}' does not exist in {self.interface}"
-        # Remove until pytorch update their docstrings
-        # assert super_method.__doc__, f"'{super_method}' has no docstring"
-        return func

--- a/ethicml/common.py
+++ b/ethicml/common.py
@@ -3,7 +3,7 @@ import os
 from importlib import util
 from pathlib import Path
 
-__all__ = ["TORCH_AVAILABLE", "TORCHVISION_AVAILABLE", "ROOT_DIR", "ROOT_PATH", "implements"]
+__all__ = ["TORCH_AVAILABLE", "TORCHVISION_AVAILABLE", "ROOT_DIR", "ROOT_PATH"]
 
 TORCH_AVAILABLE = util.find_spec("torch") is not None
 TORCHVISION_AVAILABLE = util.find_spec("torchvision") is not None

--- a/ethicml/implementations/dro_modules/dro_classifier.py
+++ b/ethicml/implementations/dro_modules/dro_classifier.py
@@ -1,10 +1,10 @@
 """Fairness without Demographics Classifier."""
 from typing import List
 
+from kit import implements
 from torch import Tensor, nn
 from torch.nn import BCELoss
 
-from ...common import implements
 from .dro_loss import DROLoss
 
 __all__ = ["DROClassifier"]

--- a/ethicml/implementations/dro_modules/dro_loss.py
+++ b/ethicml/implementations/dro_modules/dro_loss.py
@@ -1,10 +1,9 @@
 """DRO Loss."""
 from typing import Optional, Type
 
+from kit import implements
 from torch import Tensor, nn
 from torch.nn.modules.loss import NLLLoss, _Loss
-
-from ethicml.common import implements
 
 __all__ = ["DROLoss"]
 

--- a/ethicml/metrics/accuracy.py
+++ b/ethicml/metrics/accuracy.py
@@ -2,9 +2,9 @@
 from typing import Callable, Optional
 
 import pandas as pd
+from kit import implements
 from sklearn.metrics import accuracy_score, f1_score
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction
 
 from .metric import Metric

--- a/ethicml/metrics/anti_spur.py
+++ b/ethicml/metrics/anti_spur.py
@@ -1,8 +1,8 @@
 """Anti-spurious."""
 
 import numpy as np
+from kit import implements
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction
 
 from .metric import Metric

--- a/ethicml/metrics/average_odds.py
+++ b/ethicml/metrics/average_odds.py
@@ -1,7 +1,8 @@
 """For assessing Average Odds Difference metric."""
 
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .metric import Metric

--- a/ethicml/metrics/balanced_accuracy.py
+++ b/ethicml/metrics/balanced_accuracy.py
@@ -1,6 +1,7 @@
 """Accuracy that is balanced with respect to the class labels."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/metrics/bcr.py
+++ b/ethicml/metrics/bcr.py
@@ -1,6 +1,7 @@
 """For assessing Balanced Classification Rate (BCR)."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .metric import Metric

--- a/ethicml/metrics/cv.py
+++ b/ethicml/metrics/cv.py
@@ -1,6 +1,7 @@
 """For assessing Calder-Verwer metric, :math:`1-(P(Y=1|S=1)-P(Y=1|S!=1))`."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .metric import Metric

--- a/ethicml/metrics/dependence_measures.py
+++ b/ethicml/metrics/dependence_measures.py
@@ -2,10 +2,10 @@
 from typing import ClassVar
 
 import numpy as np
+from kit import implements
 from sklearn.metrics import normalized_mutual_info_score
 from typing_extensions import Literal
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction
 
 from .metric import Metric

--- a/ethicml/metrics/fnr.py
+++ b/ethicml/metrics/fnr.py
@@ -1,6 +1,7 @@
 """For assessing FNR."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/metrics/fpr.py
+++ b/ethicml/metrics/fpr.py
@@ -1,6 +1,7 @@
 """For assessing FPR."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/metrics/npv.py
+++ b/ethicml/metrics/npv.py
@@ -1,6 +1,7 @@
 """For assessing NPV."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/metrics/ppv.py
+++ b/ethicml/metrics/ppv.py
@@ -1,6 +1,7 @@
 """For assessing PPV."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/metrics/prob_neg.py
+++ b/ethicml/metrics/prob_neg.py
@@ -1,6 +1,7 @@
 """For assessing ProbNeg."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/metrics/prob_outcome.py
+++ b/ethicml/metrics/prob_outcome.py
@@ -1,6 +1,7 @@
 """For assessing mean of logits."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction, SoftPrediction
 
 from .metric import Metric

--- a/ethicml/metrics/prob_pos.py
+++ b/ethicml/metrics/prob_pos.py
@@ -1,6 +1,7 @@
 """For assessing ProbPos."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/metrics/theil.py
+++ b/ethicml/metrics/theil.py
@@ -5,8 +5,8 @@ in turn based on the paper https://arxiv.org/abs/1807.00787
 """
 
 import numpy as np
+from kit import implements
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple, Prediction
 
 from .metric import Metric

--- a/ethicml/metrics/tnr.py
+++ b/ethicml/metrics/tnr.py
@@ -1,6 +1,7 @@
 """For assessing TNR."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/metrics/tpr.py
+++ b/ethicml/metrics/tpr.py
@@ -1,6 +1,7 @@
 """For assessing TPR."""
 
-from ethicml.common import implements
+from kit import implements
+
 from ethicml.utility import DataTuple, Prediction
 
 from .confusion_matrix import confusion_matrix

--- a/ethicml/preprocessing/train_test_split.py
+++ b/ethicml/preprocessing/train_test_split.py
@@ -5,11 +5,11 @@ from typing import Dict, Iterator, List, Tuple
 
 import numpy as np
 import pandas as pd
+from kit import implements
 from numpy.random import RandomState
 from pandas.testing import assert_index_equal
 from typing_extensions import Literal
 
-from ethicml.common import implements
 from ethicml.utility import DataTuple
 from ethicml.utility.data_helpers import shuffle_df
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target-version = ['py36']
+target-version = ['py37']
 include = '''
 (
   ethicml/(.*).pyi?$
@@ -42,7 +42,5 @@ exclude = '''
 skip-string-normalization = true
 
 [tool.isort]
-include_trailing_comma = "True"
-known_third_party = ["PIL", "black", "git", "fairlearn", "matplotlib", "mypy", "numpy", "pandas", "pylint", "pytest", "scipy", "seaborn", "setuptools", "sklearn", "tap", "teext", "torch", "torchvision", "tqdm", "typing_extensions"]
-line_length = 100
-multi_line_output = 3
+known_third_party = ["PIL", "black", "git", "fairlearn", "kit", "matplotlib", "mypy", "numpy", "pandas", "pylint", "pytest", "scipy", "seaborn", "setuptools", "sklearn", "tap", "teext", "torch", "torchvision", "tqdm", "typing_extensions"]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,4 @@ skip-string-normalization = true
 [tool.isort]
 known_third_party = ["PIL", "black", "git", "fairlearn", "kit", "matplotlib", "mypy", "numpy", "pandas", "pylint", "pytest", "scipy", "seaborn", "setuptools", "sklearn", "tap", "teext", "torch", "torchvision", "tqdm", "typing_extensions"]
 profile = "black"
+line_length = 100

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+  "reportMissingTypeStubs": "none",
+  "reportUnknownParameterType": "none",
+  "reportUnknownArgumentType": "none",
+  "reportUnknownLambdaType": "none",
+  "reportUnknownVariableType": "none",
+  "reportUnknownMemberType": "none",
+  "reportMissingTypeArgument": "none"
+}

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "matplotlib >= 3.0.2",
         "numpy >= 1.20.1",
         "pandas >= 1.0",
-        "palkit >= 0.1.7"
+        "palkit >= 0.1.7",
         "pipenv >= 2018.11.26",
         "pillow",
         "scikit_learn >= 0.20.1",

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,13 @@ setup(
     url="https://github.com/predictive-analytics-lab/EthicML",
     packages=find_packages(exclude=["tests.*", "tests"]),
     package_data={"ethicml.data": ["csvs/*.csv", "csvs/*.csv.zip"], "ethicml": ["py.typed"]},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
-        'dataclasses;python_version<"3.7"',  # dataclasses are in the stdlib in python>=3.7
         "GitPython >= 2.1.11",
         "matplotlib >= 3.0.2",
-        "numpy >= 1.14.2",
+        "numpy >= 1.20.1",
         "pandas >= 1.0",
+        "palkit >= 0.1.7"
         "pipenv >= 2018.11.26",
         "pillow",
         "scikit_learn >= 0.20.1",
@@ -66,8 +66,11 @@ setup(
         ],
     },
     classifiers=[  # classifiers can be found here: https://pypi.org/classifiers/
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: OS Independent",
         "Typing :: Typed",
     ],
     zip_safe=False,

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -1,7 +1,6 @@
 """Test helper functions."""
 import pytest
-
-from ethicml.common import implements
+from kit import implements
 
 
 def test_implements() -> None:


### PR DESCRIPTION
Python 3.6 has reached end-of-life and [colab has finally upgraded to Python 3.7](https://twitter.com/googlecolab/status/1365062244225060865).