### PR TITLE
add separate fit and test functions

### DIFF
--- a/ethicml/algorithms/algorithm_base.py
+++ b/ethicml/algorithms/algorithm_base.py
@@ -28,6 +28,7 @@ class Algorithm(ABC):
 
     @property
     def seed(self) -> int:
+        """Seed for the random number generator."""
         return self.__seed
 
 

--- a/ethicml/algorithms/algorithm_base.py
+++ b/ethicml/algorithms/algorithm_base.py
@@ -11,18 +11,24 @@ __all__ = ["run_blocking", "Algorithm", "AlgorithmAsync"]
 class Algorithm(ABC):
     """Base class for Algorithms."""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, seed: int):
         """Base constructor for the Algorithm class.
 
         Args:
             name: name of the algorithm
+            seed: seed for the random number generator
         """
         self.__name = name
+        self.__seed = seed
 
     @property
     def name(self) -> str:
         """Name of the algorithm."""
         return self.__name
+
+    @property
+    def seed(self) -> int:
+        return self.__seed
 
 
 class AlgorithmAsync(metaclass=ABCMeta):  # pylint: disable=too-few-public-methods

--- a/ethicml/algorithms/algorithm_base.py
+++ b/ethicml/algorithms/algorithm_base.py
@@ -35,6 +35,8 @@ class Algorithm(ABC):
 class AlgorithmAsync(metaclass=ABCMeta):  # pylint: disable=too-few-public-methods
     """Base class of async methods; meant to be used in conjuction with :class:`Algorithm`."""
 
+    model_dir: Path
+
     @property
     def _executable(self) -> str:
         """Path to a (Python) executable.

--- a/ethicml/algorithms/inprocess/agarwal_reductions.py
+++ b/ethicml/algorithms/inprocess/agarwal_reductions.py
@@ -21,6 +21,7 @@ class Agarwal(InAlgorithmAsync):
 
     def __init__(
         self,
+        dir: Union[str, Path],
         fairness: FairnessType = "DP",
         classifier: ClassifierType = "LR",
         eps: float = 0.1,
@@ -34,6 +35,7 @@ class Agarwal(InAlgorithmAsync):
         if classifier not in VALID_MODELS:
             raise ValueError(f"results: classifier must be one of {VALID_MODELS!r}.")
         super().__init__(name=f"Agarwal, {classifier}, {fairness}", seed=seed)
+        self.model_dir = dir if isinstance(dir, Path) else Path(dir)
         chosen_c, chosen_kernel = settings_for_svm_lr(classifier, C, kernel)
         self.flags: Dict[str, Union[str, float, int]] = {
             "classifier": classifier,

--- a/ethicml/algorithms/inprocess/agarwal_reductions.py
+++ b/ethicml/algorithms/inprocess/agarwal_reductions.py
@@ -2,6 +2,8 @@
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 
+from ranzen import implements
+
 from ethicml.utility import ClassifierType, FairnessType
 
 from .in_algorithm import InAlgorithmAsync
@@ -31,7 +33,7 @@ class Agarwal(InAlgorithmAsync):
             raise ValueError(f"results: fairness must be one of {VALID_FAIRNESS!r}.")
         if classifier not in VALID_MODELS:
             raise ValueError(f"results: classifier must be one of {VALID_MODELS!r}.")
-        super().__init__(name=f"Agarwal, {classifier}, {fairness}")
+        super().__init__(name=f"Agarwal, {classifier}, {fairness}", seed=seed)
         chosen_c, chosen_kernel = settings_for_svm_lr(classifier, C, kernel)
         self.flags: Dict[str, Union[str, float, int]] = {
             "classifier": classifier,
@@ -43,6 +45,23 @@ class Agarwal(InAlgorithmAsync):
             "seed": seed,
         }
 
-    def _script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
-        args = flag_interface(train_path, test_path, pred_path, self.flags)
+    @implements(InAlgorithmAsync)
+    def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
+        args = flag_interface(
+            train_path=train_path, test_path=test_path, pred_path=pred_path, flags=self.flags
+        )
+        return ["-m", "ethicml.implementations.agarwal"] + args
+
+    @implements(InAlgorithmAsync)
+    def _fit_script_command(self, train_path: Path, model_path: Path) -> List[str]:
+        args = flag_interface(train_path=train_path, model_path=model_path, flags=self.flags)
+        return ["-m", "ethicml.implementations.agarwal"] + args
+
+    @implements(InAlgorithmAsync)
+    def _predict_script_command(
+        self, model_path: Path, test_path: Path, pred_path: Path
+    ) -> List[str]:
+        args = flag_interface(
+            model_path=model_path, test_path=test_path, pred_path=pred_path, flags=self.flags
+        )
         return ["-m", "ethicml.implementations.agarwal"] + args

--- a/ethicml/algorithms/inprocess/blind.py
+++ b/ethicml/algorithms/inprocess/blind.py
@@ -15,8 +15,18 @@ class Blind(InAlgorithm):
     """Returns a random label."""
 
     def __init__(self, seed: int = 888) -> None:
-        super().__init__(name="Blind", is_fairness_algo=False)
-        self.seed = seed
+        super().__init__(name="Blind", is_fairness_algo=False, seed=seed)
+
+    @implements(InAlgorithm)
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        self.vals = train.y.drop_duplicates()
+        return self
+
+    @implements(InAlgorithm)
+    def predict(self, test: TestTuple) -> Prediction:
+        random = np.random.RandomState(self.seed)
+
+        return Prediction(hard=pd.Series(random.choice(self.vals.T.to_numpy()[0], test.x.shape[0])))
 
     @implements(InAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:

--- a/ethicml/algorithms/inprocess/fairness_wo_demographics.py
+++ b/ethicml/algorithms/inprocess/fairness_wo_demographics.py
@@ -16,15 +16,17 @@ class DRO(InAlgorithmAsync):
 
     def __init__(
         self,
+        dir: Union[str, Path],
         eta: float = 0.5,
         epochs: int = 10,
         batch_size: int = 32,
         network_size: Optional[List[int]] = None,
         seed: int = 888,
     ):
-        super().__init__(name="Dist Robust Optim")
+        super().__init__(name="Dist Robust Optim", seed=seed)
         if network_size is None:
             network_size = [50]
+        self.model_dir = dir if isinstance(dir, Path) else Path(dir)
         self.flags: Dict[str, Union[float, int, str, List[int]]] = {
             "eta": eta,
             "batch_size": batch_size,
@@ -34,6 +36,22 @@ class DRO(InAlgorithmAsync):
         }
 
     @implements(InAlgorithmAsync)
-    def _script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
-        args = flag_interface(train_path, test_path, pred_path, self.flags)
+    def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
+        args = flag_interface(
+            train_path=train_path, test_path=test_path, pred_path=pred_path, flags=self.flags
+        )
+        return ["-m", "ethicml.implementations.dro_tabular"] + args
+
+    @implements(InAlgorithmAsync)
+    def _fit_script_command(self, train_path: Path, model_path: Path) -> List[str]:
+        args = flag_interface(train_path=train_path, model_path=model_path, flags=self.flags)
+        return ["-m", "ethicml.implementations.dro_tabular"] + args
+
+    @implements(InAlgorithmAsync)
+    def _predict_script_command(
+        self, model_path: Path, test_path: Path, pred_path: Path
+    ) -> List[str]:
+        args = flag_interface(
+            model_path=model_path, test_path=test_path, pred_path=pred_path, flags=self.flags
+        )
         return ["-m", "ethicml.implementations.dro_tabular"] + args

--- a/ethicml/algorithms/inprocess/in_algorithm.py
+++ b/ethicml/algorithms/inprocess/in_algorithm.py
@@ -1,4 +1,6 @@
 """Abstract Base Class of all algorithms in the framework."""
+from __future__ import annotations
+
 from abc import abstractmethod
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -15,9 +17,31 @@ __all__ = ["InAlgorithm", "InAlgorithmAsync"]
 class InAlgorithm(Algorithm):
     """Abstract Base Class for algorithms that run in the middle of the pipeline."""
 
-    def __init__(self, name: str, is_fairness_algo: bool = True):
-        super().__init__(name=name)
+    def __init__(self, name: str, seed: int, is_fairness_algo: bool = True):
+        super().__init__(name=name, seed=seed)
         self.__is_fairness_algo = is_fairness_algo
+
+    @abstractmethod
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        """Run Algorithm on the given data.
+
+        Args:
+            train: training data
+
+        Returns:
+            self, but trained.
+        """
+
+    @abstractmethod
+    def predict(self, test: TestTuple) -> Prediction:
+        """Run Algorithm on the given data.
+
+        Args:
+            test: data to evaluate on
+
+        Returns:
+            predictions
+        """
 
     @abstractmethod
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
@@ -46,6 +70,15 @@ class InAlgorithmAsync(InAlgorithm, AlgorithmAsync):
     """In-Algorithm that can be run blocking and asynchronously."""
 
     @implements(InAlgorithm)
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        run_blocking(self.fit_async(train))
+        return self
+
+    @implements(InAlgorithm)
+    def predict(self, test: TestTuple) -> Prediction:
+        return run_blocking(self.predict_async(test))
+
+    @implements(InAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
         """Run this asynchronous Algorithm as blocking on the given data.
 
@@ -57,6 +90,44 @@ class InAlgorithmAsync(InAlgorithm, AlgorithmAsync):
             predictions
         """
         return run_blocking(self.run_async(train, test))
+
+    async def fit_async(self, train: DataTuple) -> Prediction:
+        """Run Algorithm on the given data asynchronously.
+
+        Args:
+            train: training data
+            test: test data
+
+        Returns:
+            predictions
+        """
+        self.model_path = self.model_dir / f"model_{self.name}.joblib"
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            train_path = tmp_path / "train.npz"
+            train.to_npz(train_path)
+            cmd = self._fit_script_command(train_path, self.model_path)
+            await self._call_script(cmd + ["--mode", "fit"])  # wait for script to run
+            return self
+
+    async def predict_async(self, test: TestTuple) -> Prediction:
+        """Run Algorithm on the given data asynchronously.
+
+        Args:
+            train: training data
+            test: test data
+
+        Returns:
+            predictions
+        """
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            test_path = tmp_path / "test.npz"
+            pred_path = tmp_path / "predictions.npz"
+            test.to_npz(test_path)
+            cmd = self._predict_script_command(self.model_path, test_path, pred_path)
+            await self._call_script(cmd + ["--mode", "predict"])  # wait for scrip to run
+            return Prediction.from_npz(pred_path)
 
     async def run_async(self, train: DataTuple, test: TestTuple) -> Prediction:
         """Run Algorithm on the given data asynchronously.
@@ -75,10 +146,20 @@ class InAlgorithmAsync(InAlgorithm, AlgorithmAsync):
             pred_path = tmp_path / "predictions.npz"
             train.to_npz(train_path)
             test.to_npz(test_path)
-            cmd = self._script_command(train_path, test_path, pred_path)
-            await self._call_script(cmd)  # wait for scrip to run
+            cmd = self._run_script_command(train_path, test_path, pred_path)
+            await self._call_script(cmd + ["--mode", "run"])  # wait for scrip to run
             return Prediction.from_npz(pred_path)
 
     @abstractmethod
-    def _script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
+    def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
+        """The command that will run the script."""
+
+    @abstractmethod
+    def _fit_script_command(self, train_path: Path, model_path: Path) -> List[str]:
+        """The command that will run the script."""
+
+    @abstractmethod
+    def _predict_script_command(
+        self, model_path: Path, test_path: Path, pred_path: Path
+    ) -> List[str]:
         """The command that will run the script."""

--- a/ethicml/algorithms/inprocess/in_algorithm.py
+++ b/ethicml/algorithms/inprocess/in_algorithm.py
@@ -91,7 +91,7 @@ class InAlgorithmAsync(InAlgorithm, AlgorithmAsync):
         """
         return run_blocking(self.run_async(train, test))
 
-    async def fit_async(self, train: DataTuple) -> Prediction:
+    async def fit_async(self, train: DataTuple) -> InAlgorithmAsync:
         """Run Algorithm on the given data asynchronously.
 
         Args:

--- a/ethicml/algorithms/inprocess/installed_model.py
+++ b/ethicml/algorithms/inprocess/installed_model.py
@@ -29,6 +29,7 @@ class InstalledModel(InAlgorithmAsync):
         top_dir: str,
         url: Optional[str] = None,
         executable: Optional[str] = None,
+        seed: int = 888,
     ):
         """Download code from given URL and create Pip environment with Pipfile found in the code.
 
@@ -39,6 +40,7 @@ class InstalledModel(InAlgorithmAsync):
                      simply the last part of the repository URL)
             url: (optional) URL of the repository
             executable: (optional) path to a Python executable
+            seed: Random seed to use for reproducibility
         """
         # QUESTION: do we really need `store_dir`? we could also just clone the code into "."
         self._store_dir: Path = Path(".") / dir_name  # directory where code and venv are stored
@@ -54,7 +56,7 @@ class InstalledModel(InAlgorithmAsync):
             self.__executable = str(self._code_path.resolve() / ".venv" / "bin" / "python")
         else:
             self.__executable = executable
-        super().__init__(name=name)
+        super().__init__(name=name, seed=seed)
 
     @property
     def _code_path(self) -> Path:
@@ -90,5 +92,5 @@ class InstalledModel(InAlgorithmAsync):
         except OSError as excep:
             print(f"Error: {excep.filename} - {excep.strerror}.")
 
-    def _script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
+    def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
         return []  # pylint was complaining when I didn't return anything here...

--- a/ethicml/algorithms/inprocess/installed_model.py
+++ b/ethicml/algorithms/inprocess/installed_model.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import git
+from ranzen import implements
 
 from .in_algorithm import InAlgorithmAsync
 
@@ -92,5 +93,16 @@ class InstalledModel(InAlgorithmAsync):
         except OSError as excep:
             print(f"Error: {excep.filename} - {excep.strerror}.")
 
+    @implements(InAlgorithmAsync)
     def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
         return []  # pylint was complaining when I didn't return anything here...
+
+    @implements(InAlgorithmAsync)
+    def _fit_script_command(self, train_path: Path, model_path: Path) -> List[str]:
+        return []
+
+    @implements(InAlgorithmAsync)
+    def _predict_script_command(
+        self, model_path: Path, test_path: Path, pred_path: Path
+    ) -> List[str]:
+        return []

--- a/ethicml/algorithms/inprocess/kamiran.py
+++ b/ethicml/algorithms/inprocess/kamiran.py
@@ -28,12 +28,22 @@ class Kamiran(InAlgorithm):
         kernel: Optional[str] = None,
         seed: int = 888,
     ):
-        super().__init__(name=f"Kamiran & Calders {classifier}")
+        super().__init__(name=f"Kamiran & Calders {classifier}", seed=seed)
         if classifier not in VALID_MODELS:
             raise ValueError(f"results: classifier must be one of {VALID_MODELS!r}.")
         self.classifier = classifier
         self.C, self.kernel = settings_for_svm_lr(classifier, C, kernel)
-        self.seed = seed
+
+    @implements(InAlgorithm)
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        self.clf = _train(
+            train, classifier=self.classifier, C=self.C, kernel=self.kernel, seed=self.seed
+        )
+        return self
+
+    @implements(InAlgorithm)
+    def predict(self, test: TestTuple) -> Prediction:
+        return _predict(model=self.clf, test=test)
 
     @implements(InAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
@@ -67,6 +77,26 @@ def compute_instance_weights(
         group_weights = counts_factorized[gi_unique] / (num_samples * counts_joint)
 
     return pd.DataFrame(group_weights[inv_indexes_gi], columns=["instance weights"])
+
+
+def _train(train: DataTuple, classifier: ClassifierType, C: float, kernel: str, seed: int):
+    if classifier == "SVM":
+        model = select_svm(C=C, kernel=kernel, seed=seed)
+    else:
+        random_state = np.random.RandomState(seed=seed)
+        model = LogisticRegression(
+            solver="liblinear", random_state=random_state, max_iter=5000, C=C
+        )
+    model.fit(
+        train.x,
+        train.y.to_numpy().ravel(),
+        sample_weight=compute_instance_weights(train)["instance weights"],
+    )
+    return model
+
+
+def _predict(model, test: TestTuple):
+    return Prediction(hard=pd.Series(model.predict(test.x)))
 
 
 def _train_and_predict(

--- a/ethicml/algorithms/inprocess/kamiran.py
+++ b/ethicml/algorithms/inprocess/kamiran.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+import sklearn.linear_model._base
 from ranzen import implements
 from sklearn.linear_model import LogisticRegression
 
@@ -79,7 +80,9 @@ def compute_instance_weights(
     return pd.DataFrame(group_weights[inv_indexes_gi], columns=["instance weights"])
 
 
-def _train(train: DataTuple, classifier: ClassifierType, C: float, kernel: str, seed: int):
+def _train(
+    train: DataTuple, classifier: ClassifierType, C: float, kernel: str, seed: int
+) -> sklearn.linear_model._base.LinearModel:
     if classifier == "SVM":
         model = select_svm(C=C, kernel=kernel, seed=seed)
     else:
@@ -95,7 +98,7 @@ def _train(train: DataTuple, classifier: ClassifierType, C: float, kernel: str, 
     return model
 
 
-def _predict(model, test: TestTuple):
+def _predict(model: sklearn.linear_model._base.LinearModel, test: TestTuple) -> Prediction:
     return Prediction(hard=pd.Series(model.predict(test.x)))
 
 

--- a/ethicml/algorithms/inprocess/majority.py
+++ b/ethicml/algorithms/inprocess/majority.py
@@ -13,8 +13,17 @@ __all__ = ["Majority"]
 class Majority(InAlgorithm):
     """Simply returns the majority label from the train set."""
 
-    def __init__(self) -> None:
-        super().__init__(name="Majority", is_fairness_algo=False)
+    def __init__(self, seed: int = 888) -> None:
+        super().__init__(name="Majority", is_fairness_algo=False, seed=seed)
+
+    @implements(InAlgorithm)
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        self.maj = train.y.mode().iloc[0].to_numpy()  # type: ignore[attr-defined]
+        return self
+
+    @implements(InAlgorithm)
+    def predict(self, test: TestTuple) -> Prediction:
+        return Prediction(hard=pd.Series(self.maj.repeat(len(test.x))))
 
     @implements(InAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:

--- a/ethicml/algorithms/inprocess/mlp.py
+++ b/ethicml/algorithms/inprocess/mlp.py
@@ -30,7 +30,7 @@ class MLP(InAlgorithm):
         activation: Optional[ActivationType] = None,
         seed: int = 888,
     ):
-        super().__init__(name="MLP", is_fairness_algo=False)
+        super().__init__(name="MLP", is_fairness_algo=False, seed=seed)
         if hidden_layer_sizes is None:
             self.hidden_layer_sizes = MLPClassifier().hidden_layer_sizes
         else:
@@ -38,7 +38,16 @@ class MLP(InAlgorithm):
         self.activation: ActivationType = (
             MLPClassifier().activation if activation is None else activation
         )
-        self.seed = seed
+
+    @implements(InAlgorithm)
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        self.clf = select_mlp(self.hidden_layer_sizes, self.activation, seed=self.seed)
+        self.clf.fit(train.x, train.y.to_numpy().ravel())
+        return self
+
+    @implements(InAlgorithm)
+    def predict(self, test: TestTuple) -> Prediction:
+        return Prediction(hard=pd.Series(self.clf.predict(test.x)))
 
     @implements(InAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:

--- a/ethicml/algorithms/inprocess/oracle.py
+++ b/ethicml/algorithms/inprocess/oracle.py
@@ -17,8 +17,17 @@ class Oracle(InAlgorithm):
     but can be useful if you want to either do a sanity check, or report potential values.
     """
 
-    def __init__(self) -> None:
-        super().__init__(name="Oracle", is_fairness_algo=False)
+    def __init__(self, seed: int = 888) -> None:
+        super().__init__(name="Oracle", is_fairness_algo=False, seed=seed)
+
+    @implements(InAlgorithm)
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        return self
+
+    @implements(InAlgorithm)
+    def predict(self, test: TestTuple) -> Prediction:
+        assert isinstance(test, DataTuple), "test must be a DataTuple."
+        return Prediction(hard=test.y[test.y.columns[0]].copy())
 
     @implements(InAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
@@ -34,12 +43,23 @@ class DPOracle(InAlgorithm):
     but can be useful if you want to either do a sanity check, or report potential values.
     """
 
-    def __init__(self) -> None:
-        super().__init__(name="DemPar. Oracle", is_fairness_algo=True)
+    def __init__(self, seed: int = 888) -> None:
+        super().__init__(name="DemPar. Oracle", is_fairness_algo=True, seed=seed)
+
+    @implements(InAlgorithm)
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        return self
+
+    @implements(InAlgorithm)
+    def predict(self, test: TestTuple) -> Prediction:
+        assert isinstance(test, DataTuple), "test must be a DataTuple."
+        flipper = DPFlip(seed=self.seed)
+        test_preds = Prediction(test.y[test.y.columns[0]].copy())
+        return flipper.run(test_preds, test, test_preds, test)
 
     @implements(InAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
         assert isinstance(test, DataTuple), "test must be a DataTuple."
-        flipper = DPFlip()
+        flipper = DPFlip(seed=self.seed)
         test_preds = Prediction(test.y[test.y.columns[0]].copy())
         return flipper.run(test_preds, test, test_preds, test)

--- a/ethicml/algorithms/inprocess/shared.py
+++ b/ethicml/algorithms/inprocess/shared.py
@@ -9,13 +9,24 @@ __all__ = ["flag_interface", "settings_for_svm_lr"]
 
 
 def flag_interface(
-    train_path: Path, test_path: Path, pred_path: Path, flags: Dict[str, Any]
+    flags: Dict[str, Any],
+    *,
+    train_path: Optional[Path] = None,
+    test_path: Optional[Path] = None,
+    model_path: Optional[Path] = None,
+    pred_path: Optional[Path] = None,
 ) -> List[str]:
     """Generate the commandline arguments that are expected by the script about to be called."""
     # paths to training and test data
-    data_flags: Dict[str, Any] = {"train": train_path, "test": test_path}
-    # paths to output files
-    data_flags.update({"predictions": pred_path})
+    data_flags: Dict[str, Any] = {}
+    if train_path is not None:
+        data_flags["train"] = train_path
+    if test_path is not None:
+        data_flags["test"] = test_path
+    if model_path is not None:
+        data_flags["model"] = model_path
+    if pred_path is not None:
+        data_flags["predictions"] = pred_path
     data_flags.update(flags)
 
     flags_list: List[str] = []

--- a/ethicml/algorithms/inprocess/svm.py
+++ b/ethicml/algorithms/inprocess/svm.py
@@ -18,10 +18,19 @@ class SVM(InAlgorithm):
 
     def __init__(self, C: Optional[float] = None, kernel: Optional[str] = None, seed: int = 888):
         kernel_name = f" ({kernel})" if kernel is not None else ""
-        super().__init__(name="SVM" + kernel_name, is_fairness_algo=False)
+        super().__init__(name="SVM" + kernel_name, is_fairness_algo=False, seed=seed)
         self.C = SVC().C if C is None else C
         self.kernel = SVC().kernel if kernel is None else kernel
-        self.seed = seed
+
+    @implements(InAlgorithm)
+    def fit(self, train: DataTuple) -> InAlgorithm:
+        self.clf = select_svm(self.C, self.kernel, self.seed)
+        self.clf.fit(train.x, train.y.to_numpy().ravel())
+        return self
+
+    @implements(InAlgorithm)
+    def predict(self, test: TestTuple) -> Prediction:
+        return Prediction(hard=pd.Series(self.clf.predict(test.x)))
 
     @implements(InAlgorithm)
     def run(self, train: DataTuple, test: Union[DataTuple, TestTuple]) -> Prediction:

--- a/ethicml/algorithms/inprocess/svm_async.py
+++ b/ethicml/algorithms/inprocess/svm_async.py
@@ -1,7 +1,8 @@
 """Wrapper for SKLearn implementation of SVM."""
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 
+from ranzen import implements
 from sklearn.svm import SVC
 
 from ethicml.algorithms.inprocess.in_algorithm import InAlgorithmAsync
@@ -14,14 +15,38 @@ __all__ = ["SVMAsync"]
 class SVMAsync(InAlgorithmAsync):
     """Support Vector Machine."""
 
-    def __init__(self, C: Optional[float] = None, kernel: Optional[str] = None, seed: int = 888):
-        super().__init__(name="SVM", is_fairness_algo=False)
+    def __init__(
+        self,
+        dir: Union[str, Path],
+        C: Optional[float] = None,
+        kernel: Optional[str] = None,
+        seed: int = 888,
+    ):
+        super().__init__(name="SVM", is_fairness_algo=False, seed=seed)
+        self.model_dir = dir if isinstance(dir, Path) else Path(dir)
         self.flags = {
             "c": SVC().C if C is None else C,
             "kernel": SVC().kernel if kernel is None else kernel,
             "seed": seed,
         }
 
-    def _script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
-        args = flag_interface(train_path, test_path, pred_path, self.flags)
+    @implements(InAlgorithmAsync)
+    def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:
+        args = flag_interface(
+            train_path=train_path, test_path=test_path, pred_path=pred_path, flags=self.flags
+        )
+        return ["-m", "ethicml.implementations.svm"] + args
+
+    @implements(InAlgorithmAsync)
+    def _fit_script_command(self, train_path: Path, model_path: Path) -> List[str]:
+        args = flag_interface(train_path=train_path, model_path=model_path, flags=self.flags)
+        return ["-m", "ethicml.implementations.svm"] + args
+
+    @implements(InAlgorithmAsync)
+    def _predict_script_command(
+        self, model_path: Path, test_path: Path, pred_path: Path
+    ) -> List[str]:
+        args = flag_interface(
+            model_path=model_path, test_path=test_path, pred_path=pred_path, flags=self.flags
+        )
         return ["-m", "ethicml.implementations.svm"] + args

--- a/ethicml/algorithms/postprocess/dp_flip.py
+++ b/ethicml/algorithms/postprocess/dp_flip.py
@@ -15,8 +15,7 @@ class DPFlip(PostAlgorithm):
     """Randomly flip a number of decisions such that perfect demographic parity is achieved."""
 
     def __init__(self, seed: int = 888) -> None:
-        super().__init__(name="DemPar. Post Process")
-        self.seed = seed
+        super().__init__(name="DemPar. Post Process", seed=seed)
 
     @implements(PostAlgorithm)
     def run(

--- a/ethicml/algorithms/postprocess/dp_flip.py
+++ b/ethicml/algorithms/postprocess/dp_flip.py
@@ -18,6 +18,20 @@ class DPFlip(PostAlgorithm):
         super().__init__(name="DemPar. Post Process", seed=seed)
 
     @implements(PostAlgorithm)
+    def fit(self, train_predictions: Prediction, train: DataTuple) -> PostAlgorithm:
+        return self
+
+    @implements(PostAlgorithm)
+    def predict(self, test_predictions: Prediction, test: TestTuple) -> Prediction:
+        x, y = self._fit(test, test_predictions)
+        _test_preds = self._flip(
+            test_predictions, test, flip_0_to_1=True, num_to_flip=x, s_group=0, seed=self.seed
+        )
+        return self._flip(
+            _test_preds, test, flip_0_to_1=False, num_to_flip=y, s_group=1, seed=self.seed
+        )
+
+    @implements(PostAlgorithm)
     def run(
         self,
         train_predictions: Prediction,

--- a/ethicml/algorithms/postprocess/hardt.py
+++ b/ethicml/algorithms/postprocess/hardt.py
@@ -25,6 +25,15 @@ class Hardt(PostAlgorithm):
         self._random = RandomState(seed=self.seed)
 
     @implements(PostAlgorithm)
+    def fit(self, train_predictions: Prediction, train: DataTuple) -> PostAlgorithm:
+        self.model_params = self._fit(train_predictions, train)
+        return self
+
+    @implements(PostAlgorithm)
+    def predict(self, test_predictions: Prediction, test: TestTuple) -> Prediction:
+        return self._predict(self.model_params, test_predictions, test)
+
+    @implements(PostAlgorithm)
     def run(
         self,
         train_predictions: Prediction,

--- a/ethicml/algorithms/postprocess/hardt.py
+++ b/ethicml/algorithms/postprocess/hardt.py
@@ -19,10 +19,10 @@ class Hardt(PostAlgorithm):
     """Post-processing method by Hardt et al."""
 
     def __init__(self, unfavorable_label: int = 0, favorable_label: int = 1, seed: int = 888):
-        super().__init__(name="Hardt")
+        super().__init__(name="Hardt", seed=seed)
         self._unfavorable_label = unfavorable_label
         self._favorable_label = favorable_label
-        self._random = RandomState(seed=seed)
+        self._random = RandomState(seed=self.seed)
 
     @implements(PostAlgorithm)
     def run(

--- a/ethicml/algorithms/postprocess/post_algorithm.py
+++ b/ethicml/algorithms/postprocess/post_algorithm.py
@@ -1,4 +1,5 @@
 """Abstract Base Class of all post-processing algorithms in the framework."""
+from __future__ import annotations
 
 from abc import abstractmethod
 
@@ -11,6 +12,28 @@ __all__ = ["PostAlgorithm"]
 
 class PostAlgorithm(Algorithm):
     """Abstract Base Class for all algorithms that do post-processing."""
+
+    @abstractmethod
+    def fit(self, train_predictions: Prediction, train: DataTuple) -> PostAlgorithm:
+        """Run Algorithm on the given data.
+
+        Args:
+            train: training data
+
+        Returns:
+            self, but trained.
+        """
+
+    @abstractmethod
+    def predict(self, test_predictions: Prediction, test: TestTuple) -> Prediction:
+        """Run Algorithm on the given data.
+
+        Args:
+            test: data to evaluate on
+
+        Returns:
+            predictions
+        """
 
     @abstractmethod
     def run(

--- a/ethicml/algorithms/preprocess/beutel.py
+++ b/ethicml/algorithms/preprocess/beutel.py
@@ -30,7 +30,7 @@ class Beutel(PreAlgorithmAsync):
         seed: int = 888,
     ):
         # pylint: disable=too-many-arguments
-        super().__init__(name=f"Beutel {fairness}")
+        super().__init__(name=f"Beutel {fairness}", seed=seed)
         self.flags: Dict[str, Union[str, Sequence[int], int, float]] = {
             "fairness": fairness,
             "enc_size": enc_size,

--- a/ethicml/algorithms/preprocess/calders.py
+++ b/ethicml/algorithms/preprocess/calders.py
@@ -14,8 +14,8 @@ __all__ = ["Calders"]
 class Calders(PreAlgorithm):
     """Massaging algorithm from Kamiran&Calders 2012."""
 
-    def __init__(self, preferable_class: int, disadvantaged_group: int):
-        super().__init__(name="Calders")
+    def __init__(self, preferable_class: int, disadvantaged_group: int, seed: int = 888):
+        super().__init__(name="Calders", seed=seed)
         self.preferable_class = preferable_class
         self.disadvantaged_group = disadvantaged_group
 

--- a/ethicml/algorithms/preprocess/interface.py
+++ b/ethicml/algorithms/preprocess/interface.py
@@ -1,20 +1,30 @@
 """Methods that define commandline interfaces."""
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 def flag_interface(
-    train_path: Path,
-    test_path: Path,
-    new_train_path: Path,
-    new_test_path: Path,
     flags: Dict[str, Any],
+    train_path: Optional[Path] = None,
+    test_path: Optional[Path] = None,
+    new_train_path: Optional[Path] = None,
+    new_test_path: Optional[Path] = None,
+    model_path: Optional[Path] = None,
 ) -> List[str]:
     """Generate the commandline arguments that are expected by the script about to be called."""
     # paths to training and test data
-    data_flags: Dict[str, Any] = {"train": train_path, "test": test_path}
+    data_flags: Dict[str, Any] = {}
+    if train_path is not None:
+        data_flags["train"] = str(train_path)
+    if new_train_path is not None:
+        data_flags["new_train"] = str(new_train_path)
+    if test_path is not None:
+        data_flags["test"] = str(test_path)
+    if new_test_path is not None:
+        data_flags["new_test"] = str(new_test_path)
+    if model_path is not None:
+        data_flags["model"] = str(model_path)
     # paths to output files
-    data_flags.update({"new_train": new_train_path, "new_test": new_test_path})
     data_flags.update(flags)
 
     flags_list: List[str] = []

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -74,6 +74,7 @@ class PreAlgorithm(Algorithm):
 
     @property
     def out_size(self):
+        """The number of features to generate."""
         return self._out_size
 
 

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -1,9 +1,11 @@
 """Abstract Base Class of all algorithms in the framework."""
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, Tuple
+from typing import List, Optional, Tuple, TypeVar
 
 from ranzen import implements
 
@@ -12,9 +14,46 @@ from ethicml.utility import DataTuple, TestTuple
 
 __all__ = ["PreAlgorithm", "PreAlgorithmAsync"]
 
+T = TypeVar("T", DataTuple, TestTuple)
+
 
 class PreAlgorithm(Algorithm):
     """Abstract Base Class for all algorithms that do pre-processing."""
+
+    def __init__(self, name: str, seed: int, out_size: Optional[int]):
+        """Base constructor for the Algorithm class.
+
+        Args:
+            name: name of the algorithm
+            seed: seed for the random number generator
+            out_size: number of features to generate
+        """
+        super().__init__(name=name, seed=seed)
+        self._out_size = out_size
+
+    @abstractmethod
+    def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
+        """Generate fair features with the given data.
+
+        Args:
+            train: training data
+            test: test data
+
+        Returns:
+            a tuple of the pre-processed training data and the test data
+        """
+
+    @abstractmethod
+    def transform(self, data: T) -> T:
+        """Generate fair features with the given data.
+
+        Args:
+            train: training data
+            test: test data
+
+        Returns:
+            a tuple of the pre-processed training data and the test data
+        """
 
     @abstractmethod
     def run(self, train: DataTuple, test: TestTuple) -> Tuple[DataTuple, TestTuple]:
@@ -33,9 +72,22 @@ class PreAlgorithm(Algorithm):
         train_testing = train.get_subset()
         return self.run(train_testing, test)
 
+    @property
+    def out_size(self):
+        return self._out_size
+
 
 class PreAlgorithmAsync(PreAlgorithm, AlgorithmAsync):
     """Pre-Algorithm that can be run blocking and asynchronously."""
+
+    @implements(PreAlgorithm)
+    def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
+        model, data = run_blocking(self.fit_async(train))
+        return self, data
+
+    @implements(PreAlgorithm)
+    def transform(self, data: T) -> T:
+        return run_blocking(self.transform_async(data))
 
     @implements(PreAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Tuple[DataTuple, TestTuple]:
@@ -49,6 +101,73 @@ class PreAlgorithmAsync(PreAlgorithm, AlgorithmAsync):
             a tuple of the pre-processed training data and the test data
         """
         return run_blocking(self.run_async(train, test))
+
+    async def fit_async(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
+        """Generate fair features with the given data asynchronously.
+
+        Args:
+            train: training data
+            test: test data
+
+        Returns:
+            a tuple of the pre-processed training data and the test data
+        """
+        self.model_path = self.model_dir / f"model_{self.name}.joblib"
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            # ================================ write data to files ================================
+            train_path, test_path = tmp_path / "train.npz", tmp_path / "test.npz"
+            train.to_npz(train_path)
+
+            # ========================== generate commandline arguments ===========================
+            transformed_train_path = tmp_path / "transformed_train.npz"
+            cmd = self._fit_script_command(train_path, transformed_train_path, self.model_path)
+
+            # ============================= run the generated command =============================
+            await self._call_script(cmd + ["--mode", "fit"])
+
+            # ================================== load results =====================================
+            transformed_train = DataTuple.from_npz(transformed_train_path)
+
+        # prefix the name of the algorithm to the dataset name
+        transformed_train = transformed_train.replace(
+            name=None if train.name is None else f"{self.name}: {train.name}"
+        )
+        return self, transformed_train
+
+    async def transform_async(self, data: T) -> T:
+        """Generate fair features with the given data asynchronously.
+
+        Args:
+            train: training data
+            test: test data
+
+        Returns:
+            a tuple of the pre-processed training data and the test data
+        """
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            # ================================ write data to files ================================
+            test_path = tmp_path / "test.npz"
+            data.to_npz(test_path)
+
+            # ========================== generate commandline arguments ===========================
+            transformed_test_path = tmp_path / "transformed_test.npz"
+            cmd = self._transform_script_command(
+                model_path=self.model_path, test_path=test_path, new_test_path=transformed_test_path
+            )
+
+            # ============================= run the generated command =============================
+            await self._call_script(cmd + ["--mode", "transform"])
+
+            # ================================== load results =====================================
+            transformed_test = TestTuple.from_npz(transformed_test_path)
+
+        # prefix the name of the algorithm to the dataset name
+        transformed_test = transformed_test.replace(
+            name=None if data.name is None else f"{self.name}: {data.name}"
+        )
+        return transformed_test
 
     async def run_async(self, train: DataTuple, test: TestTuple) -> Tuple[DataTuple, TestTuple]:
         """Generate fair features with the given data asynchronously.
@@ -70,12 +189,12 @@ class PreAlgorithmAsync(PreAlgorithm, AlgorithmAsync):
             # ========================== generate commandline arguments ===========================
             transformed_train_path = tmp_path / "transformed_train.npz"
             transformed_test_path = tmp_path / "transformed_test.npz"
-            cmd = self._script_command(
+            cmd = self._run_script_command(
                 train_path, test_path, transformed_train_path, transformed_test_path
             )
 
             # ============================= run the generated command =============================
-            await self._call_script(cmd)
+            await self._call_script(cmd + ["--mode", "run"])
 
             # ================================== load results =====================================
             transformed_train = DataTuple.from_npz(transformed_train_path)
@@ -91,7 +210,19 @@ class PreAlgorithmAsync(PreAlgorithm, AlgorithmAsync):
         return transformed_train, transformed_test
 
     @abstractmethod
-    def _script_command(
+    def _run_script_command(
         self, train_path: Path, test_path: Path, new_train_path: Path, new_test_path: Path
+    ) -> List[str]:
+        """The command that will run the script."""
+
+    @abstractmethod
+    def _fit_script_command(
+        self, train_path: Path, new_train_path: Path, model_path: Path
+    ) -> List[str]:
+        """The command that will run the script."""
+
+    @abstractmethod
+    def _transform_script_command(
+        self, model_path: Path, test_path: Path, new_test_path: Path
     ) -> List[str]:
         """The command that will run the script."""

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -73,8 +73,9 @@ class PreAlgorithm(Algorithm):
         return self.run(train_testing, test)
 
     @property
-    def out_size(self):
+    def out_size(self) -> int:
         """The number of features to generate."""
+        assert self._out_size is not None
         return self._out_size
 
 

--- a/ethicml/algorithms/preprocess/upsampler.py
+++ b/ethicml/algorithms/preprocess/upsampler.py
@@ -24,11 +24,10 @@ class Upsampler(PreAlgorithm):
     def __init__(
         self, strategy: Literal["uniform", "preferential", "naive"] = "uniform", seed: int = 888
     ):
-        super().__init__(name=f"Upsample {strategy}")
+        super().__init__(name=f"Upsample {strategy}", seed=seed)
 
         assert strategy in ["uniform", "preferential", "naive"]
         self.strategy = strategy
-        self.seed = seed
 
     @implements(PreAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Tuple[DataTuple, TestTuple]:

--- a/ethicml/algorithms/preprocess/vfae.py
+++ b/ethicml/algorithms/preprocess/vfae.py
@@ -24,7 +24,7 @@ class VFAE(PreAlgorithmAsync):
         seed: int = 888,
     ):
         # pylint: disable=too-many-arguments
-        super().__init__(name="VFAE")
+        super().__init__(name="VFAE", seed=seed)
 
         if z1_enc_size is None:
             z1_enc_size = [100]

--- a/ethicml/algorithms/preprocess/zemel.py
+++ b/ethicml/algorithms/preprocess/zemel.py
@@ -23,7 +23,7 @@ class Zemel(PreAlgorithmAsync):
         epsilon: float = 1e-5,
         seed: int = 888,
     ) -> None:
-        super().__init__(name="Zemel")
+        super().__init__(name="Zemel", seed=seed)
         self.flags: Dict[str, Union[int, float]] = {
             "clusters": clusters,
             "Ax": Ax,

--- a/ethicml/algorithms/preprocess/zemel.py
+++ b/ethicml/algorithms/preprocess/zemel.py
@@ -1,11 +1,15 @@
 """Zemel's Learned Fair Representations."""
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
+
+from ranzen import implements
 
 from .interface import flag_interface
-from .pre_algorithm import PreAlgorithmAsync
+from .pre_algorithm import PreAlgorithm, PreAlgorithmAsync
 
 __all__ = ["Zemel"]
+
+from ethicml.utility import DataTuple, TestTuple
 
 
 class Zemel(PreAlgorithmAsync):
@@ -13,6 +17,7 @@ class Zemel(PreAlgorithmAsync):
 
     def __init__(
         self,
+        dir: Union[str, Path],
         threshold: float = 0.5,
         clusters: int = 2,
         Ax: float = 0.01,
@@ -23,7 +28,8 @@ class Zemel(PreAlgorithmAsync):
         epsilon: float = 1e-5,
         seed: int = 888,
     ) -> None:
-        super().__init__(name="Zemel", seed=seed)
+        super().__init__(name="Zemel", seed=seed, out_size=None)
+        self.model_dir = dir if isinstance(dir, Path) else Path(dir)
         self.flags: Dict[str, Union[int, float]] = {
             "clusters": clusters,
             "Ax": Ax,
@@ -36,8 +42,54 @@ class Zemel(PreAlgorithmAsync):
             "seed": seed,
         }
 
-    def _script_command(
+    @implements(PreAlgorithm)
+    def run(self, train: DataTuple, test: TestTuple) -> Tuple[DataTuple, TestTuple]:
+        self._out_size = train.x.shape[1]
+        return super().run(train, test)
+
+    @implements(PreAlgorithm)
+    def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
+        self._out_size = train.x.shape[1]
+        return super().fit(train)
+
+    @implements(PreAlgorithmAsync)
+    def fit_async(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
+        self._out_size = train.x.shape[1]
+        return super().fit_async(train)
+
+    @implements(PreAlgorithmAsync)
+    def _run_script_command(
         self, train_path: Path, test_path: Path, new_train_path: Path, new_test_path: Path
     ) -> List[str]:
-        args = flag_interface(train_path, test_path, new_train_path, new_test_path, self.flags)
+        args = flag_interface(
+            train_path=train_path,
+            test_path=test_path,
+            new_train_path=new_train_path,
+            new_test_path=new_test_path,
+            flags=self.flags,
+        )
+        return ["-m", "ethicml.implementations.zemel"] + args
+
+    @implements(PreAlgorithmAsync)
+    def _fit_script_command(
+        self, train_path: Path, new_train_path: Path, model_path: Path
+    ) -> List[str]:
+        args = flag_interface(
+            train_path=train_path,
+            new_train_path=new_train_path,
+            model_path=model_path,
+            flags=self.flags,
+        )
+        return ["-m", "ethicml.implementations.zemel"] + args
+
+    @implements(PreAlgorithmAsync)
+    def _transform_script_command(
+        self, model_path: Path, test_path: Path, new_test_path: Path
+    ) -> List[str]:
+        args = flag_interface(
+            model_path=model_path,
+            test_path=test_path,
+            new_test_path=new_test_path,
+            flags=self.flags,
+        )
         return ["-m", "ethicml.implementations.zemel"] + args

--- a/ethicml/data/tabular_data/acs_income.py
+++ b/ethicml/data/tabular_data/acs_income.py
@@ -48,7 +48,6 @@ def acs_income(
     root: Path,
     year: str,
     horizon: int,
-    survey: str,
     states: List[str],
     split: str = "Sex",
     target_threshold: int = 50_000,
@@ -59,7 +58,6 @@ def acs_income(
         root=root,
         year=year,
         horizon=horizon,
-        survey=survey,
         states=states,
         split=split,
         target_threshold=target_threshold,
@@ -75,7 +73,6 @@ class AcsIncome(Dataset):
         root: Union[str, Path],
         year: str,
         horizon: int,
-        survey: str,
         states: List[str],
         split: str = "Sex",
         target_threshold: int = 50_000,
@@ -90,7 +87,7 @@ class AcsIncome(Dataset):
 
         self.year = year
         self.horizon = horizon
-        self.survey = survey
+        self.survey = "person"
         self.states = states
         self.split = split
         self.target = "PINCP"
@@ -102,7 +99,7 @@ class AcsIncome(Dataset):
         self.sens_lookup = {"Sex": "SEX", "Race": "RAC1P"}
 
         state_string = "_".join(states)
-        self.name = f"ACS_Income_{year}_{survey}_{horizon}_{state_string}_{split}"
+        self.name = f"ACS_Income_{year}_{horizon}_{state_string}_{split}"
         self.class_label_spec = "PINCP_1"
         self.class_label_prefix = ["PINCP"]
         self.discard_non_one_hot = False

--- a/ethicml/data/tabular_data/acs_income.py
+++ b/ethicml/data/tabular_data/acs_income.py
@@ -35,7 +35,7 @@ class AdultSplits(Enum):
 
 
 @contextlib.contextmanager
-def download_dir(root: Path):
+def download_dir(root: Path) -> None:
     curdir = os.getcwd()
     os.chdir(root.expanduser().resolve())
     try:

--- a/ethicml/data/tabular_data/german.py
+++ b/ethicml/data/tabular_data/german.py
@@ -14,15 +14,6 @@ class GermanSplits(Enum):
     CUSTOM = "Custom"
 
 
-def german(
-    split: Union[GermanSplits, str] = "Sex",
-    discrete_only: bool = False,
-    invert_s: bool = False,
-):
-    """German credit dataset."""
-    return German(split=split, discrete_only=discrete_only, invert_s=invert_s)
-
-
 class German(Dataset):
     """German credit dataset."""
 
@@ -145,3 +136,12 @@ class German(Dataset):
             discrete_feature_groups=disc_feature_groups,
             invert_s=invert_s,
         )
+
+
+def german(
+    split: Union[GermanSplits, str] = "Sex",
+    discrete_only: bool = False,
+    invert_s: bool = False,
+) -> German:
+    """German credit dataset."""
+    return German(split=split, discrete_only=discrete_only, invert_s=invert_s)

--- a/ethicml/data/tabular_data/toy.py
+++ b/ethicml/data/tabular_data/toy.py
@@ -14,7 +14,7 @@ def toy() -> Dataset:
 class Toy(Dataset):
     """Dataset with toy data for testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         disc_feature_groups = {
             "disc_1": ["disc_1_a", "disc_1_b", "disc_1_c", "disc_1_d", "disc_1_e"],
             "disc_2": ["disc_2_x", "disc_2_y", "disc_2_z"],

--- a/ethicml/implementations/agarwal.py
+++ b/ethicml/implementations/agarwal.py
@@ -1,9 +1,12 @@
 """Implementation of logistic regression (actually just a wrapper around sklearn)."""
+import contextlib
+import os
 import random
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from joblib import dump, load
 from sklearn.linear_model import LogisticRegression
 
 from ethicml.algorithms.inprocess.svm import select_svm
@@ -24,8 +27,8 @@ class AgarwalArgs(InAlgoArgs):
     seed: int
 
 
-def train_and_predict(train: DataTuple, test: TestTuple, args: AgarwalArgs) -> pd.DataFrame:
-    """Train a logistic regression model and compute predictions on the given test data."""
+def fit(train: DataTuple, args):
+    """Fit a model."""
     try:
         from fairlearn.reductions import (
             ConditionalSelectionRate,
@@ -35,9 +38,6 @@ def train_and_predict(train: DataTuple, test: TestTuple, args: AgarwalArgs) -> p
         )
     except ImportError as e:
         raise RuntimeError("In order to use Agarwal, install fairlearn.") from e
-
-    random.seed(args.seed)
-    np.random.seed(args.seed)
 
     fairness_class: ConditionalSelectionRate
     if args.fairness == "DP":
@@ -62,20 +62,80 @@ def train_and_predict(train: DataTuple, test: TestTuple, args: AgarwalArgs) -> p
     )
     exponentiated_gradient.fit(data_x, data_y, sensitive_features=data_a)
 
+    min_class_label = train.y[train.y.columns[0]].min()
+    exponentiated_gradient.min_class_label = min_class_label
+
+    return exponentiated_gradient
+
+
+def predict(exponentiated_gradient, test: TestTuple) -> pd.DataFrame:
+    """Compute predictions on the given test data."""
     randomized_predictions = exponentiated_gradient.predict(test.x)
     preds = pd.DataFrame(randomized_predictions, columns=["preds"])
 
-    min_class_label = train.y[train.y.columns[0]].min()
     if preds["preds"].min() != preds["preds"].max():
-        preds = preds.replace(preds["preds"].min(), min_class_label)
+        preds = preds.replace(preds["preds"].min(), exponentiated_gradient.min_class_label)
     return preds
+
+
+def train_and_predict(train: DataTuple, test: TestTuple, args: AgarwalArgs) -> pd.DataFrame:
+    """Train a logistic regression model and compute predictions on the given test data."""
+    exponentiated_gradient = train(train, args)
+    return predict(exponentiated_gradient, test)
+
+
+@contextlib.contextmanager
+def working_dir(root: Path) -> None:
+    """Change the working directory to the given path."""
+    curdir = os.getcwd()
+    os.chdir(root.expanduser().resolve().parent)
+    try:
+        yield
+    finally:
+        os.chdir(curdir)
 
 
 def main() -> None:
     """This function runs the Agarwal model as a standalone program."""
     args: AgarwalArgs = AgarwalArgs().parse_args()
-    train, test = DataTuple.from_npz(Path(args.train)), TestTuple.from_npz(Path(args.test))
-    Prediction(hard=train_and_predict(train, test, args)["preds"]).to_npz(Path(args.predictions))
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    try:
+        import cloudpickle
+
+        # Need to install cloudpickle for now. See https://github.com/fairlearn/fairlearn/issues/569
+    except ImportError as e:
+        raise RuntimeError("In order to use Agarwal, install fairlearn and cloudpickle.") from e
+
+    if args.mode == "run":
+        assert args.train is not None
+        assert args.test is not None
+        assert args.predictions is not None
+        train, test = DataTuple.from_npz(Path(args.train)), TestTuple.from_npz(Path(args.test))
+        Prediction(hard=train_and_predict(train, test, args)["preds"]).to_npz(
+            Path(args.predictions)
+        )
+    elif args.mode == "fit":
+        assert args.train is not None
+        assert args.model is not None
+        data = DataTuple.from_npz(Path(args.train))
+        model = fit(data, args)
+        with working_dir(Path(args.model)):
+            model_file = cloudpickle.dumps(model)
+        dump(model_file, Path(args.model))
+    elif args.mode == "predict":
+        assert args.model is not None
+        assert args.predictions is not None
+        assert args.test is not None
+        data = TestTuple.from_npz(Path(args.test))
+        model_file = load(Path(args.model))
+        with working_dir(Path(args.model)):
+            model = cloudpickle.loads(model_file)
+        Prediction(hard=predict(model, data)["preds"]).to_npz(Path(args.predictions))
+    else:
+        raise RuntimeError(f"Unknown mode: {args.mode}")
+        model = pickle.loads(model_file)
+        predict(model, data, args).to_npz(Path(args.predictions))
 
 
 if __name__ == "__main__":

--- a/ethicml/implementations/agarwal.py
+++ b/ethicml/implementations/agarwal.py
@@ -80,7 +80,7 @@ def predict(exponentiated_gradient, test: TestTuple) -> pd.DataFrame:
 
 def train_and_predict(train: DataTuple, test: TestTuple, args: AgarwalArgs) -> pd.DataFrame:
     """Train a logistic regression model and compute predictions on the given test data."""
-    exponentiated_gradient = train(train, args)
+    exponentiated_gradient = fit(train, args)
     return predict(exponentiated_gradient, test)
 
 
@@ -134,8 +134,6 @@ def main() -> None:
         Prediction(hard=predict(model, data)["preds"]).to_npz(Path(args.predictions))
     else:
         raise RuntimeError(f"Unknown mode: {args.mode}")
-        model = pickle.loads(model_file)
-        predict(model, data, args).to_npz(Path(args.predictions))
 
 
 if __name__ == "__main__":

--- a/ethicml/implementations/dro_tabular.py
+++ b/ethicml/implementations/dro_tabular.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pandas as pd
 import torch
+from joblib import dump, load
 from torch import optim
 from torch.optim.optimizer import Optimizer  # pylint: disable=no-name-in-module
 from torch.utils.data import DataLoader
@@ -50,6 +51,45 @@ def train_model(
     print(f"====> Epoch: {epoch} Average loss: {train_loss / len(train_loader.dataset):.4f}")  # type: ignore[arg-type]
 
 
+def fit(train: DataTuple, args: DroArgs) -> DROClassifier:
+    """Train a network and return predictions."""
+    # Set up the data
+    set_seed(args.seed)
+    train_data = CustomDataset(train)
+    train_loader = DataLoader(train_data, batch_size=args.batch_size)
+
+    # Build Network
+    model = DROClassifier(
+        in_size=train_data.xdim,
+        out_size=train_data.ydim,
+        network_size=args.network_size,
+        eta=args.eta,
+    ).to("cpu")
+    optimizer = optim.Adam(model.parameters(), lr=1e-3)
+
+    # Run Network
+    for epoch in range(int(args.epochs)):
+        train_model(epoch, model, train_loader, optimizer)
+    return model
+
+
+def predict(model: DROClassifier, test: TestTuple, args: DroArgs) -> SoftPrediction:
+    """Train a network and return predictions."""
+    # Set up the data
+    test_data = TestDataset(test)
+    test_loader = DataLoader(test_data, batch_size=args.batch_size)
+
+    # Transform output
+    post_test: List[List[float]] = []
+    model.eval()
+    with torch.no_grad():
+        for _x, _s in test_loader:
+            out = model.forward(_x)
+            post_test += out.data.tolist()
+
+    return SoftPrediction(soft=pd.Series([j for i in post_test for j in i]))
+
+
 def train_and_predict(train: DataTuple, test: TestTuple, args: DroArgs) -> SoftPrediction:
     """Train a network and return predictions."""
     # Set up the data
@@ -87,8 +127,25 @@ def train_and_predict(train: DataTuple, test: TestTuple, args: DroArgs) -> SoftP
 def main() -> None:
     """This function runs the FWD model as a standalone program on tabular data."""
     args = DroArgs().parse_args()
-    train, test = load_data_from_flags(args)
-    train_and_predict(train, test, args).to_npz(Path(args.predictions))
+    if args.mode == "run":
+        assert args.train is not None
+        assert args.test is not None
+        assert args.predictions is not None
+        train, test = load_data_from_flags(args)
+        train_and_predict(train, test, args).to_npz(Path(args.predictions))
+    elif args.mode == "fit":
+        assert args.train is not None
+        assert args.model is not None
+        data = DataTuple.from_npz(Path(args.train))
+        model = fit(data, args)
+        dump(model, Path(args.model))
+    elif args.mode == "predict":
+        assert args.model is not None
+        assert args.predictions is not None
+        assert args.test is not None
+        data = TestTuple.from_npz(Path(args.test))
+        model = load(Path(args.model))
+        predict(model, data, args).to_npz(Path(args.predictions))
 
 
 if __name__ == "__main__":

--- a/ethicml/implementations/utils.py
+++ b/ethicml/implementations/utils.py
@@ -46,5 +46,7 @@ def save_transformations(transforms: Tuple[DataTuple, TestTuple], args: PreAlgoA
     train, test = transforms
     assert isinstance(train, DataTuple)
     assert isinstance(test, TestTuple)
+    assert args.new_train is not None
+    assert args.new_test is not None
     train.to_npz(Path(args.new_train))
     test.to_npz(Path(args.new_test))

--- a/ethicml/implementations/utils.py
+++ b/ethicml/implementations/utils.py
@@ -13,6 +13,8 @@ class AlgoArgs(tap.Tap):
     # paths to the files with the data
     train: Optional[str] = None
     test: Optional[str] = None
+    mode: str
+    model: Optional[str] = None
 
 
 class PreAlgoArgs(AlgoArgs):
@@ -23,17 +25,15 @@ class PreAlgoArgs(AlgoArgs):
     """
 
     # paths to where the processed inputs should be stored
-    new_train: str
-    new_test: str
+    new_train: Optional[str] = None
+    new_test: Optional[str] = None
 
 
 class InAlgoArgs(AlgoArgs):
     """ArgumentParser that already has arguments for the paths needed for InAlgorithms."""
 
     # path to where the predictions should be stored
-    mode: str
     predictions: Optional[str] = None
-    model: Optional[str] = None
 
 
 def load_data_from_flags(args: AlgoArgs) -> Tuple[DataTuple, TestTuple]:

--- a/ethicml/implementations/utils.py
+++ b/ethicml/implementations/utils.py
@@ -1,6 +1,6 @@
 """Useful functions used in implementations."""
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import tap
 
@@ -11,8 +11,8 @@ class AlgoArgs(tap.Tap):
     """Base arguments needed for all algorithms."""
 
     # paths to the files with the data
-    train: str
-    test: str
+    train: Optional[str] = None
+    test: Optional[str] = None
 
 
 class PreAlgoArgs(AlgoArgs):
@@ -31,7 +31,9 @@ class InAlgoArgs(AlgoArgs):
     """ArgumentParser that already has arguments for the paths needed for InAlgorithms."""
 
     # path to where the predictions should be stored
-    predictions: str
+    mode: str
+    predictions: Optional[str] = None
+    model: Optional[str] = None
 
 
 def load_data_from_flags(args: AlgoArgs) -> Tuple[DataTuple, TestTuple]:

--- a/ethicml/implementations/vfae.py
+++ b/ethicml/implementations/vfae.py
@@ -1,6 +1,6 @@
 """Implementation of VFAE."""
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 import pandas as pd
 import torch
@@ -47,6 +47,7 @@ def fit(train, flags):
 
 def transform(model: VFAENetwork, dataset: T, flags) -> T:
     """Transform the dataset."""
+    data: Union[CustomDataset, TestDataset]
     if isinstance(dataset, DataTuple):
         data = CustomDataset(dataset)
         loader = DataLoader(data, batch_size=flags.batch_size, shuffle=False)

--- a/ethicml/implementations/vfae_modules/utils.py
+++ b/ethicml/implementations/vfae_modules/utils.py
@@ -21,6 +21,7 @@ class VfaeArgs(PreAlgoArgs):
     batch_size: int
     epochs: int
     dataset: str
+    latent_dims: int
     z1_enc_size: List[int]
     z2_enc_size: List[int]
     z1_dec_size: List[int]

--- a/poetry.lock
+++ b/poetry.lock
@@ -205,6 +205,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
+name = "cloudpickle"
+version = "2.0.0"
+description = "Extended pickling support for Python objects"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
@@ -704,7 +712,7 @@ python-versions = "*"
 
 [[package]]
 name = "mypy"
-version = "0.920"
+version = "0.921"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -1631,13 +1639,13 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-all = ["fairlearn"]
-ci = ["fairlearn", "pytest", "pytest-cov", "torch", "torchvision"]
+all = ["fairlearn", "cloudpickle"]
+ci = ["fairlearn", "pytest", "pytest-cov", "torch", "torchvision", "cloudpickle"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<4.0"
-content-hash = "68ff268ebe9a26f6cc78eecd9d4048df48ee93b16a407d97a784c2dbc7273970"
+content-hash = "0f1afc0b35c633f00ff203d947876a9102f43772be188af6c768a6d5fb834368"
 
 [metadata.files]
 appdirs = [
@@ -1773,6 +1781,10 @@ charset-normalizer = [
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
     {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
+]
+cloudpickle = [
+    {file = "cloudpickle-2.0.0-py3-none-any.whl", hash = "sha256:6b2df9741d06f43839a3275c4e6632f7df6487a1f181f5f46a052d3c917c3d11"},
+    {file = "cloudpickle-2.0.0.tar.gz", hash = "sha256:5cd02f3b417a783ba84a4ec3e290ff7929009fe51f6405423cfccfadd43ba4a4"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -2140,26 +2152,26 @@ mistune = [
     {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
 ]
 mypy = [
-    {file = "mypy-0.920-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41f3575b20714171c832d8f6c7aaaa0d499c9a2d1b8adaaf837b4c9065c38540"},
-    {file = "mypy-0.920-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:431be889ffc8d9681813a45575c42e341c19467cbfa6dd09bf41467631feb530"},
-    {file = "mypy-0.920-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f8b2059f73878e92eff7ed11a03515d6572f4338a882dd7547b5f7dd242118e6"},
-    {file = "mypy-0.920-cp310-cp310-win_amd64.whl", hash = "sha256:9cd316e9705555ca6a50670ba5fb0084d756d1d8cb1697c83820b1456b0bc5f3"},
-    {file = "mypy-0.920-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e091fe58b4475b3504dc7c3022ff7f4af2f9e9ddf7182047111759ed0973bbde"},
-    {file = "mypy-0.920-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98b4f91a75fed2e4c6339e9047aba95968d3a7c4b91e92ab9dc62c0c583564f4"},
-    {file = "mypy-0.920-cp36-cp36m-win_amd64.whl", hash = "sha256:562a0e335222d5bbf5162b554c3afe3745b495d67c7fe6f8b0d1b5bace0c1eeb"},
-    {file = "mypy-0.920-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:618e677aabd21f30670bffb39a885a967337f5b112c6fb7c79375e6dced605d6"},
-    {file = "mypy-0.920-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40cb062f1b7ff4cd6e897a89d8ddc48c6ad7f326b5277c93a8c559564cc1551c"},
-    {file = "mypy-0.920-cp37-cp37m-win_amd64.whl", hash = "sha256:69b5a835b12fdbfeed84ef31152d41343d32ccb2b345256d8682324409164330"},
-    {file = "mypy-0.920-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:993c2e52ea9570e6e872296c046c946377b9f5e89eeb7afea2a1524cf6e50b27"},
-    {file = "mypy-0.920-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:df0fec878ccfcb2d1d2306ba31aa757848f681e7bbed443318d9bbd4b0d0fe9a"},
-    {file = "mypy-0.920-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:331a81d2c9bf1be25317260a073b41f4584cd11701a7c14facef0aa5a005e843"},
-    {file = "mypy-0.920-cp38-cp38-win_amd64.whl", hash = "sha256:ffb1e57ec49a30e3c0ebcfdc910ae4aceb7afb649310b7355509df6b15bd75f6"},
-    {file = "mypy-0.920-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:31895b0b3060baf15bf76e789d94722c026f673b34b774bba9e8772295edccff"},
-    {file = "mypy-0.920-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:140174e872d20d4768124a089b9f9fc83abd6a349b7f8cc6276bc344eb598922"},
-    {file = "mypy-0.920-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:13b3c110309b53f5a62aa1b360f598124be33a42563b790a2a9efaacac99f1fc"},
-    {file = "mypy-0.920-cp39-cp39-win_amd64.whl", hash = "sha256:82e6c15675264e923b60a11d6eb8f90665504352e68edfbb4a79aac7a04caddd"},
-    {file = "mypy-0.920-py3-none-any.whl", hash = "sha256:71c77bd885d2ce44900731d4652d0d1c174dc66a0f11200e0c680bdedf1a6b37"},
-    {file = "mypy-0.920.tar.gz", hash = "sha256:a55438627f5f546192f13255a994d6d1cf2659df48adcf966132b4379fd9c86b"},
+    {file = "mypy-0.921-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d9d6a9c35ac1e5d89d9f71f60d4932dfba00b8d2cb0ba758293f0214c851d2c0"},
+    {file = "mypy-0.921-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:01ff922b9fa13f451ce51f7b707c97e35b5dd6ad0104a83d598306255cc7f990"},
+    {file = "mypy-0.921-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:279d87385acc33d4117612002026d09ef039845dee2cab41d2cca38ca63a72b3"},
+    {file = "mypy-0.921-cp310-cp310-win_amd64.whl", hash = "sha256:f4688e06b2bbb9708eda50bf119abf072833687ca25c11caf84371fb44722b8a"},
+    {file = "mypy-0.921-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:54bfe651425cc0935e056327c8f0da749015d64e1586601a9350363f4a3a7794"},
+    {file = "mypy-0.921-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:aadc06bffbe00c285771056e5b0364bc3e0a814e3a08d2cc64f4b12ea40bc283"},
+    {file = "mypy-0.921-cp36-cp36m-win_amd64.whl", hash = "sha256:49e528bf13d54a4cbb163fc7532ae220edf0b1bb79070481c77a0c83cc4e36ce"},
+    {file = "mypy-0.921-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1952b1c8e84eb03375b5e339295a96b92dd5b865d2a9768431c9c5aa58f8d32b"},
+    {file = "mypy-0.921-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2d816a6e2114c473181e0df3013decb9a02acbc57d45454357a05258acd528a3"},
+    {file = "mypy-0.921-cp37-cp37m-win_amd64.whl", hash = "sha256:777fc39141b8a4154c61cc6dc0315b25832b8b6efe5a2bef1dba66d5544341d4"},
+    {file = "mypy-0.921-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8fcad97e6be583c7de2d18304581dc7f8c42ce4950df5d56005bd3efd53e9ef9"},
+    {file = "mypy-0.921-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:71c193bc6dc1b2f183b59f6473a13e627885751d9e534fd26bf15bc8eeed8772"},
+    {file = "mypy-0.921-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b64e64fb6092c86239a7b10437c8e0b9b013e704ecdf8bdfaa8d80dbd7ba2a73"},
+    {file = "mypy-0.921-cp38-cp38-win_amd64.whl", hash = "sha256:02aca528afcb965ea7bf2bc5fbe5736225b5786e135d64cce5075e3bc8b785a4"},
+    {file = "mypy-0.921-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:59f6280e3cbb961b7a9957b6e1739c60fd027743c5ec4d3636f1ae24d5249528"},
+    {file = "mypy-0.921-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:549557f7dc7ddd45ca08df0944b7f6519a0e23e6336ef3ff260a4e100fe1ccb3"},
+    {file = "mypy-0.921-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b6f6bc11222b61fa805371f18d70f1546f5ca26db5eda8ad9a75364460bd17a0"},
+    {file = "mypy-0.921-cp39-cp39-win_amd64.whl", hash = "sha256:8c2cff600d34ea8f3426a470e0ea75bd35c75269f6df69a9320c99b4e92edca4"},
+    {file = "mypy-0.921-py3-none-any.whl", hash = "sha256:6e57f340ea04a6f7c67c7757e573bc61c2cc096f87ebd829d7c3264dedc0bc54"},
+    {file = "mypy-0.921.tar.gz", hash = "sha256:eca089d7053dff45d6dcd5bf67f1cabc311591e85d378917d97363e7c13da088"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ module = [
     "black.*",
     "fairlearn.*",
     "imageio",
+    "joblib",
     "pandas.testing",
     "pylint.*",
     "pytest.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ tqdm = ">=4.31.1"
 typed-argument-parser = "1.4"
 typing-extensions = ">=3.7.2"
 fairlearn = { version = "0.4.6", optional = true }
+cloudpickle = { version = "^2.0.0", optional= true }
 pytest = { version = "^6.0.0", optional = true }
 pytest-cov = { version = "^2.6.0", optional = true }
 torch = { version = "^1.8", optional = true }
@@ -45,8 +46,8 @@ folktables = "^0.0.11"
 ranzen = "^1.1.1"
 
 [tool.poetry.extras]
-ci = ["fairlearn","pytest","pytest-cov","torch","torchvision"]
-all= ["fairlearn"]
+ci = ["fairlearn","pytest","pytest-cov","torch","torchvision","cloudpickle"]
+all= ["fairlearn","cloudpickle"]
 
 
 [tool.poetry.dev-dependencies]

--- a/tests/loading_data_test.py
+++ b/tests/loading_data_test.py
@@ -502,9 +502,7 @@ def idfn(val: DT):
             sum_y=231,
         ),
         DT(
-            dataset=em.acs_income(
-                root=Path("~/Data"), year="2018", horizon=1, survey="person", states=["AL"]
-            ),
+            dataset=em.acs_income(root=Path("~/Data"), year="2018", horizon=1, states=["AL"]),
             samples=22_268,
             x_features=45,
             discrete_features=40,
@@ -512,14 +510,25 @@ def idfn(val: DT):
             num_sens=2,
             y_features=1,
             num_labels=2,
-            name="ACS_Income_2018_person_1_AL_Sex",
+            name="ACS_Income_2018_1_AL_Sex",
             sum_s=11_622,
             sum_y=6_924,
         ),
         DT(
-            dataset=em.acs_income(
-                root=Path("~/Data"), year="2018", horizon=1, survey="person", states=["AL", "PA"]
-            ),
+            dataset=em.acs_income(root=Path("~/Data"), year="2018", horizon=1, states=["PA"]),
+            samples=68_308,
+            x_features=45,
+            discrete_features=40,
+            s_features=1,
+            num_sens=2,
+            y_features=1,
+            num_labels=2,
+            name="ACS_Income_2018_1_PA_Sex",
+            sum_s=35_480,
+            sum_y=24_385,
+        ),
+        DT(
+            dataset=em.acs_income(root=Path("~/Data"), year="2018", horizon=1, states=["AL", "PA"]),
             samples=90_576,
             x_features=45,
             discrete_features=40,
@@ -527,18 +536,13 @@ def idfn(val: DT):
             num_sens=2,
             y_features=1,
             num_labels=2,
-            name="ACS_Income_2018_person_1_AL_PA_Sex",
+            name="ACS_Income_2018_1_AL_PA_Sex",
             sum_s=47_102,
             sum_y=31_309,
         ),
         DT(
             dataset=em.acs_income(
-                root=Path("~/Data"),
-                year="2018",
-                horizon=1,
-                survey="person",
-                states=["AL"],
-                split="Race",
+                root=Path("~/Data"), year="2018", horizon=1, states=["AL"], split="Race"
             ),
             samples=22_268,
             x_features=38,
@@ -547,18 +551,13 @@ def idfn(val: DT):
             num_sens=9,
             y_features=1,
             num_labels=2,
-            name="ACS_Income_2018_person_1_AL_Race",
+            name="ACS_Income_2018_1_AL_Race",
             sum_s=9_947,
             sum_y=6_924,
         ),
         DT(
             dataset=em.acs_income(
-                root=Path("~/Data"),
-                year="2018",
-                horizon=1,
-                survey="person",
-                states=["AL"],
-                split="Sex-Race",
+                root=Path("~/Data"), year="2018", horizon=1, states=["AL"], split="Sex-Race"
             ),
             samples=22_268,
             x_features=36,
@@ -567,7 +566,7 @@ def idfn(val: DT):
             num_sens=17,
             y_features=1,
             num_labels=2,
-            name="ACS_Income_2018_person_1_AL_Sex-Race",
+            name="ACS_Income_2018_1_AL_Sex-Race",
             sum_s=31_516,
             sum_y=6_924,
         ),

--- a/tests/models_test/inprocess_test/models_inprocessing_test.py
+++ b/tests/models_test/inprocess_test/models_inprocessing_test.py
@@ -1,7 +1,7 @@
 """EthicML Tests."""
 import sys
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Tuple
+from typing import Dict, List, NamedTuple
 
 import pandas as pd
 import pytest
@@ -55,6 +55,24 @@ class InprocessTest(NamedTuple):
 
 
 INPROCESS_TESTS = [
+    InprocessTest(name="Agarwal, LR, DP", model=Agarwal(dir='/tmp'), num_pos=45),
+    InprocessTest(name="Agarwal, LR, EqOd", model=Agarwal(dir='/tmp', fairness="EqOd"), num_pos=44),
+    InprocessTest(name="Agarwal, SVM, DP", model=Agarwal(dir='/tmp', classifier="SVM"), num_pos=45),
+    InprocessTest(
+        name="Agarwal, SVM, DP",
+        model=Agarwal(dir='/tmp', classifier="SVM", kernel="linear"),
+        num_pos=42,
+    ),
+    InprocessTest(
+        name="Agarwal, SVM, EqOd",
+        model=Agarwal(dir='/tmp', classifier="SVM", fairness="EqOd"),
+        num_pos=45,
+    ),
+    InprocessTest(
+        name="Agarwal, SVM, EqOd",
+        model=Agarwal(dir='/tmp', classifier="SVM", fairness="EqOd", kernel="linear"),
+        num_pos=42,
+    ),
     InprocessTest(name="Blind", model=Blind(), num_pos=48),
     InprocessTest(name="DemPar. Oracle", model=DPOracle(), num_pos=53),
     InprocessTest(name="Dist Robust Optim", model=DRO(eta=0.5, dir="/tmp"), num_pos=45),
@@ -204,51 +222,6 @@ def test_local_installed_lr(toy_train_test: TrainTestPair):
     expected_num_pos = 44
     assert count_true(predictions.hard.values == 1) == expected_num_pos
     assert count_true(predictions.hard.values == 0) == len(predictions) - expected_num_pos
-
-
-def test_agarwal(toy_train_test: TrainTestPair):
-    """Test agarwal."""
-    train, test = toy_train_test
-
-    agarwal_variants: List[InAlgorithmAsync] = []
-    model_names: List[str] = []
-    expected_results: List[Tuple[int, int]] = []
-
-    agarwal_variants.append(Agarwal())
-    model_names.append("Agarwal, LR, DP")
-    expected_results.append((45, 35))
-
-    agarwal_variants.append(Agarwal(fairness="EqOd"))
-    model_names.append("Agarwal, LR, EqOd")
-    expected_results.append((44, 36))
-
-    agarwal_variants.append(Agarwal(classifier="SVM"))
-    model_names.append("Agarwal, SVM, DP")
-    expected_results.append((45, 35))
-
-    agarwal_variants.append(Agarwal(classifier="SVM", kernel="linear"))
-    model_names.append("Agarwal, SVM, DP")
-    expected_results.append((42, 38))
-
-    agarwal_variants.append(Agarwal(classifier="SVM", fairness="EqOd"))
-    model_names.append("Agarwal, SVM, EqOd")
-    expected_results.append((45, 35))
-
-    agarwal_variants.append(Agarwal(classifier="SVM", fairness="EqOd", kernel="linear"))
-    model_names.append("Agarwal, SVM, EqOd")
-    expected_results.append((42, 38))
-
-    results = run_blocking(
-        run_in_parallel(agarwal_variants, [TrainTestPair(train, test)], max_parallel=1)
-    )
-
-    for model, results_for_model, model_name, (pred_true, pred_false) in zip(
-        agarwal_variants, results, model_names, expected_results
-    ):
-        assert model.name == model_name
-        print(model.name)
-        assert count_true(results_for_model[0].hard.to_numpy() == 1) == pred_true, model_name
-        assert count_true(results_for_model[0].hard.to_numpy() == 0) == pred_false, model_name
 
 
 def test_threaded_agarwal():

--- a/tests/models_test/postprocess_test/models_postprocessing_test.py
+++ b/tests/models_test/postprocess_test/models_postprocessing_test.py
@@ -1,14 +1,33 @@
 """EthicML tests."""
+from typing import NamedTuple
+
 import pytest
 
 import ethicml as em
-from ethicml import LR, Hardt, InAlgorithm, PostAlgorithm, Prediction, ProbPos, TrainTestPair
+from ethicml import LR, Hardt, InAlgorithm, PostAlgorithm, Prediction, ProbPos
 from ethicml.algorithms.postprocess.dp_flip import DPFlip
 from ethicml.utility.data_structures import TrainValPair
 from tests.run_algorithm_test import count_true
 
 
-def test_dp_flip(toy_train_test: TrainValPair) -> None:
+class PostprocessTest(NamedTuple):
+    """Define a test for an postprocess model."""
+
+    post_model: PostAlgorithm
+    name: str
+    num_pos: int
+
+
+@pytest.mark.parametrize(
+    "post_model,name,num_pos",
+    [
+        PostprocessTest(post_model=DPFlip(), name="DemPar. Post Process", num_pos=57),
+        PostprocessTest(post_model=Hardt(), name="Hardt", num_pos=35),
+    ],
+)
+def test_post(
+    toy_train_test: TrainValPair, post_model: PostAlgorithm, name: str, num_pos: int
+) -> None:
     """Test the dem par flipping method."""
     train, test = toy_train_test
     train_test = em.concat_tt([train, test], ignore_index=True)
@@ -25,16 +44,55 @@ def test_dp_flip(toy_train_test: TrainValPair) -> None:
     assert count_true(pred_test.values == 1) == 44
     assert count_true(pred_test.values == 0) == 36
 
-    post_model: PostAlgorithm = DPFlip()
-    assert post_model.name == "DemPar. Post Process"
+    assert post_model.name == name
     fair_preds = post_model.run(Prediction(pred_train), train, Prediction(pred_test), test)
-    assert count_true(fair_preds.hard.values == 1) == 57
-    assert count_true(fair_preds.hard.values == 0) == 23
+    assert count_true(fair_preds.hard.values == 1) == num_pos
+    assert count_true(fair_preds.hard.values == 0) == len(fair_preds) - num_pos
     diffs = em.diff_per_sensitive_attribute(
         em.metric_per_sensitive_attribute(fair_preds, test, ProbPos())
     )
-    for diff in diffs.values():
-        assert pytest.approx(diff, abs=1e-2) == 0
+    if isinstance(post_model, DPFlip):
+        for diff in diffs.values():
+            assert pytest.approx(diff, abs=1e-2) == 0
+
+
+@pytest.mark.parametrize(
+    "post_model,name,num_pos",
+    [
+        PostprocessTest(post_model=DPFlip(), name="DemPar. Post Process", num_pos=57),
+        PostprocessTest(post_model=Hardt(), name="Hardt", num_pos=35),
+    ],
+)
+def test_post_sep_fit_pred(
+    toy_train_test: TrainValPair, post_model: PostAlgorithm, name: str, num_pos: int
+) -> None:
+    """Test the dem par flipping method."""
+    train, test = toy_train_test
+    train_test = em.concat_tt([train, test], ignore_index=True)
+
+    in_model: InAlgorithm = LR()
+    assert in_model is not None
+    assert in_model.name == "Logistic Regression (C=1.0)"
+
+    predictions: Prediction = in_model.run(train, train_test)
+
+    # seperate out predictions on train set and predictions on test set
+    pred_train = predictions.hard.iloc[: train.y.shape[0]]
+    pred_test = predictions.hard.iloc[train.y.shape[0] :].reset_index(drop=True)
+    assert count_true(pred_test.values == 1) == 44
+    assert count_true(pred_test.values == 0) == 36
+
+    assert post_model.name == name
+    fair_model = post_model.fit(Prediction(pred_train), train)
+    fair_preds = fair_model.predict(Prediction(pred_test), test)
+    assert count_true(fair_preds.hard.values == 1) == num_pos
+    assert count_true(fair_preds.hard.values == 0) == len(fair_preds) - num_pos
+    diffs = em.diff_per_sensitive_attribute(
+        em.metric_per_sensitive_attribute(fair_preds, test, ProbPos())
+    )
+    if isinstance(post_model, DPFlip):
+        for diff in diffs.values():
+            assert pytest.approx(diff, abs=1e-2) == 0
 
 
 def test_dp_flip_inverted_s(toy_train_test: TrainValPair) -> None:
@@ -66,30 +124,3 @@ def test_dp_flip_inverted_s(toy_train_test: TrainValPair) -> None:
     )
     for diff in diffs.values():
         assert pytest.approx(diff, abs=1e-2) == 0
-
-
-def test_hardt(toy_train_test: TrainTestPair) -> None:
-    """Tests the hardt postprocessing technique.
-
-    Args:
-        toy_train_test: Train-test pair of toy data
-    """
-    train, test = toy_train_test
-    train_test = em.concat_tt([train, test], ignore_index=True)
-
-    in_model: InAlgorithm = LR()
-    assert in_model is not None
-    assert in_model.name == "Logistic Regression (C=1.0)"
-
-    predictions: Prediction = in_model.run(train, train_test)
-
-    # seperate out predictions on train set and predictions on test set
-    pred_train = predictions.hard.iloc[: train.y.shape[0]]
-    pred_test = predictions.hard.iloc[train.y.shape[0] :]
-    assert count_true(pred_test.values == 1) == 44
-    assert count_true(pred_test.values == 0) == 36
-
-    post_model: PostAlgorithm = Hardt()
-    fair_preds = post_model.run(Prediction(pred_train), train, Prediction(pred_test), test)
-    assert count_true(fair_preds.hard.values == 1) == 35
-    assert count_true(fair_preds.hard.values == 0) == 45

--- a/tests/saving_data_test.py
+++ b/tests/saving_data_test.py
@@ -31,7 +31,7 @@ def test_simple_saving() -> None:
         """Dummy algorithm class for testing whether writing and reading feather files works."""
 
         def __init__(self) -> None:
-            super().__init__(name="Check equality")
+            super().__init__(name="Check equality", seed=-1)
 
         def _run_script_command(self, train_path, _, pred_path):
             """Check if the dataframes loaded from the files are the same as the original ones."""
@@ -42,6 +42,12 @@ def test_simple_saving() -> None:
             # write a file for the predictions
             np.savez(pred_path, hard=np.load(train_path)["x"])
             return ["-c", "pass"]
+
+        def _fit_script_command(self, train_path, model_path):
+            """Check if the dataframes loaded from the files are the same as the original ones."""
+
+        def _predict_script_command(self, model_path, test_path, pred_path):
+            """Check if the dataframes loaded from the files are the same as the original ones."""
 
     data_x = run_blocking(CheckEquality().run_async(data_tuple, data_tuple))
     pd.testing.assert_series_equal(  # type: ignore[call-arg]

--- a/tests/saving_data_test.py
+++ b/tests/saving_data_test.py
@@ -33,7 +33,7 @@ def test_simple_saving() -> None:
         def __init__(self) -> None:
             super().__init__(name="Check equality")
 
-        def _script_command(self, train_path, _, pred_path):
+        def _run_script_command(self, train_path, _, pred_path):
             """Check if the dataframes loaded from the files are the same as the original ones."""
             loaded = DataTuple.from_npz(train_path)
             pd.testing.assert_frame_equal(data_tuple.x, loaded.x)


### PR DESCRIPTION
Added separate fit and predict methods for the InProcessing models.

This is mostly just splitting up what's already packaged together in various `train_and_predict` functions.

The bit that needs double checking is for the async algos. Here a model save location now gets passed, then the trained model is just dumped there. I'm not sure if there's a better way to do this or not. I imagine that there is.

There's now quite a lot of duplication. This should really be sorted.... 