### PR TITLE
Remove `__init__` from algorithm base classes

### DIFF
--- a/ethicml/algorithms/algorithm_base.py
+++ b/ethicml/algorithms/algorithm_base.py
@@ -1,41 +1,27 @@
 """Base class for Algorithms."""
 import subprocess
 import sys
-from abc import ABC, ABCMeta
+from abc import abstractmethod
 from pathlib import Path
 from typing import Dict, List, Optional
+from typing_extensions import Protocol
 
 __all__ = ["Algorithm", "SubprocessAlgorithmMixin"]
 
 
-class Algorithm(ABC):
+class Algorithm(Protocol):
     """Base class for Algorithms."""
 
-    def __init__(self, name: str, seed: int):
-        """Base constructor for the Algorithm class.
-
-        Args:
-            name: name of the algorithm
-            seed: seed for the random number generator
-        """
-        self.__name = name
-        self.__seed = seed
+    seed: int
 
     @property
+    @abstractmethod
     def name(self) -> str:
         """Name of the algorithm."""
-        return self.__name
-
-    @property
-    def seed(self) -> int:
-        """Seed for the random number generator."""
-        return self.__seed
 
 
-class SubprocessAlgorithmMixin(metaclass=ABCMeta):  # pylint: disable=too-few-public-methods
+class SubprocessAlgorithmMixin(Protocol):  # pylint: disable=too-few-public-methods
     """Base class of async methods; meant to be used in conjuction with :class:`Algorithm`."""
-
-    model_dir: Path
 
     @property
     def _executable(self) -> str:

--- a/ethicml/algorithms/inprocess/agarwal_reductions.py
+++ b/ethicml/algorithms/inprocess/agarwal_reductions.py
@@ -34,7 +34,8 @@ class Agarwal(InAlgorithmAsync):
             raise ValueError(f"results: fairness must be one of {VALID_FAIRNESS!r}.")
         if classifier not in VALID_MODELS:
             raise ValueError(f"results: classifier must be one of {VALID_MODELS!r}.")
-        super().__init__(name=f"Agarwal, {classifier}, {fairness}", seed=seed)
+        self.seed = seed
+        self.is_fairness_algo = True
         self.model_dir = dir if isinstance(dir, Path) else Path(dir)
         chosen_c, chosen_kernel = settings_for_svm_lr(classifier, C, kernel)
         self.flags: Dict[str, Union[str, float, int]] = {
@@ -46,6 +47,11 @@ class Agarwal(InAlgorithmAsync):
             "kernel": chosen_kernel,
             "seed": seed,
         }
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return f"Agarwal, {self.flags['classifier']}, {self.flags['fairness']}"
 
     @implements(InAlgorithmAsync)
     def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:

--- a/ethicml/algorithms/inprocess/blind.py
+++ b/ethicml/algorithms/inprocess/blind.py
@@ -1,4 +1,5 @@
 """Simply returns a random (but legal) label."""
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
@@ -6,34 +7,27 @@ from ranzen import implements
 
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
-from .in_algorithm import InAlgorithm
+from .in_algorithm import InAlgorithmDC
 
 __all__ = ["Blind"]
 
 
-class Blind(InAlgorithm):
+@dataclass
+class Blind(InAlgorithmDC):
     """Returns a random label."""
 
-    def __init__(self, seed: int = 888) -> None:
-        super().__init__(name="Blind", is_fairness_algo=False, seed=seed)
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "Blind"
 
-    @implements(InAlgorithm)
-    def fit(self, train: DataTuple) -> InAlgorithm:
+    @implements(InAlgorithmDC)
+    def fit(self, train: DataTuple) -> InAlgorithmDC:
         self.vals = train.y.drop_duplicates()
         return self
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def predict(self, test: TestTuple) -> Prediction:
         random = np.random.RandomState(self.seed)
 
         return Prediction(hard=pd.Series(random.choice(self.vals.T.to_numpy()[0], test.x.shape[0])))
-
-    @implements(InAlgorithm)
-    def run(self, train: DataTuple, test: TestTuple) -> Prediction:
-        train_y_vals = train.y.drop_duplicates()
-
-        random = np.random.RandomState(self.seed)
-
-        return Prediction(
-            hard=pd.Series(random.choice(train_y_vals.T.to_numpy()[0], test.x.shape[0]))
-        )

--- a/ethicml/algorithms/inprocess/fairness_wo_demographics.py
+++ b/ethicml/algorithms/inprocess/fairness_wo_demographics.py
@@ -23,7 +23,8 @@ class DRO(InAlgorithmAsync):
         network_size: Optional[List[int]] = None,
         seed: int = 888,
     ):
-        super().__init__(name="Dist Robust Optim", seed=seed)
+        self.seed = seed
+        self.is_fairness_algo = True
         if network_size is None:
             network_size = [50]
         self.model_dir = dir if isinstance(dir, Path) else Path(dir)
@@ -34,6 +35,11 @@ class DRO(InAlgorithmAsync):
             "network_size": network_size,
             "seed": seed,
         }
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "Dist Robust Optim"
 
     @implements(InAlgorithmAsync)
     def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:

--- a/ethicml/algorithms/inprocess/in_algorithm.py
+++ b/ethicml/algorithms/inprocess/in_algorithm.py
@@ -5,27 +5,27 @@ from abc import abstractmethod
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, TypeVar
+from typing_extensions import Protocol, runtime_checkable
 
 from ranzen import implements
 
 from ethicml.algorithms.algorithm_base import Algorithm, SubprocessAlgorithmMixin
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
-__all__ = ["InAlgorithm", "InAlgorithmAsync"]
+__all__ = ["InAlgorithm", "InAlgorithmAsync", "InAlgorithmDC"]
 
 _I = TypeVar("_I", bound="InAlgorithm")
 
 
-class InAlgorithm(Algorithm):
+@runtime_checkable
+class InAlgorithm(Algorithm, Protocol):
     """Abstract Base Class for algorithms that run in the middle of the pipeline."""
 
-    def __init__(self, name: str, seed: int, is_fairness_algo: bool = True):
-        super().__init__(name=name, seed=seed)
-        self.__is_fairness_algo = is_fairness_algo
+    is_fairness_algo: bool
 
     @abstractmethod
     def fit(self: _I, train: DataTuple) -> _I:
-        """Run Algorithm on the given data.
+        """Fit Algorithm on the given data.
 
         Args:
             train: training data
@@ -36,7 +36,7 @@ class InAlgorithm(Algorithm):
 
     @abstractmethod
     def predict(self, test: TestTuple) -> Prediction:
-        """Run Algorithm on the given data.
+        """Make predictions on the given data.
 
         Args:
             test: data to evaluate on
@@ -45,7 +45,6 @@ class InAlgorithm(Algorithm):
             predictions
         """
 
-    @abstractmethod
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
         """Run Algorithm on the given data.
 
@@ -56,23 +55,30 @@ class InAlgorithm(Algorithm):
         Returns:
             predictions
         """
+        self.fit(train)
+        return self.predict(test)
 
     def run_test(self, train: DataTuple, test: TestTuple) -> Prediction:
         """Run with reduced training set so that it finishes quicker."""
         train_testing = train.get_subset()
         return self.run(train_testing, test)
 
-    @property
-    def is_fairness_algo(self) -> bool:
-        """True if this class corresponds to a fair algorithm."""
-        return self.__is_fairness_algo
+
+@dataclass  # type: ignore  # mypy doesn't allow abstract dataclasses because mypy is stupid
+class InAlgorithmDC(InAlgorithm):
+    """InAlgorithm dataclass base class."""
+
+    is_fairness_algo = True
+    seed: int = 888
 
 
 _IA = TypeVar("_IA", bound="InAlgorithmAsync")
 
 
-class InAlgorithmAsync(SubprocessAlgorithmMixin, InAlgorithm):
+class InAlgorithmAsync(SubprocessAlgorithmMixin, InAlgorithm, Protocol):
     """In-Algorithm that uses a subprocess to run."""
+
+    model_dir: Path
 
     @implements(InAlgorithm)
     def fit(self: _IA, train: DataTuple) -> _IA:
@@ -85,12 +91,11 @@ class InAlgorithmAsync(SubprocessAlgorithmMixin, InAlgorithm):
         Returns:
             predictions
         """
-        self.model_path = self.model_dir / f"model_{self.name}.joblib"
         with TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             train_path = tmp_path / "train.npz"
             train.to_npz(train_path)
-            cmd = self._fit_script_command(train_path, self.model_path)
+            cmd = self._fit_script_command(train_path, self._model_path)
             self._call_script(cmd + ["--mode", "fit"])  # wait for script to run
             return self
 
@@ -110,7 +115,7 @@ class InAlgorithmAsync(SubprocessAlgorithmMixin, InAlgorithm):
             test_path = tmp_path / "test.npz"
             pred_path = tmp_path / "predictions.npz"
             test.to_npz(test_path)
-            cmd = self._predict_script_command(self.model_path, test_path, pred_path)
+            cmd = self._predict_script_command(self._model_path, test_path, pred_path)
             self._call_script(cmd + ["--mode", "predict"])  # wait for scrip to run
             return Prediction.from_npz(pred_path)
 
@@ -135,6 +140,10 @@ class InAlgorithmAsync(SubprocessAlgorithmMixin, InAlgorithm):
             cmd = self._run_script_command(train_path, test_path, pred_path)
             self._call_script(cmd + ["--mode", "run"])  # wait for scrip to run
             return Prediction.from_npz(pred_path)
+
+    @property
+    def _model_path(self) -> Path:
+        return self.model_dir / f"model_{self.name}.joblib"
 
     @abstractmethod
     def _run_script_command(self, train_path: Path, test_path: Path, pred_path: Path) -> List[str]:

--- a/ethicml/algorithms/inprocess/in_algorithm.py
+++ b/ethicml/algorithms/inprocess/in_algorithm.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, TypeVar

--- a/ethicml/algorithms/inprocess/installed_model.py
+++ b/ethicml/algorithms/inprocess/installed_model.py
@@ -13,9 +13,8 @@ from pathlib import Path
 from typing import Optional
 
 import git
-from ranzen.decorators import implements
 
-from ..algorithm_base import Algorithm, SubprocessAlgorithmMixin
+from ..algorithm_base import SubprocessAlgorithmMixin
 from .in_algorithm import InAlgorithm
 
 __all__ = ["InstalledModel"]
@@ -42,6 +41,7 @@ class InstalledModel(SubprocessAlgorithmMixin, InAlgorithm):
             dir_name: where to download the code to (can be chosen freely)
             top_dir: top directory of the repository where the Pipfile can be found (this is usually
                      simply the last part of the repository URL)
+            is_fairness_algo: if True, this object corresponds to an algorithm enforcing fairness
             url: (optional) URL of the repository
             executable: (optional) path to a Python executable
             seed: Random seed to use for reproducibility

--- a/ethicml/algorithms/inprocess/installed_model.py
+++ b/ethicml/algorithms/inprocess/installed_model.py
@@ -13,8 +13,9 @@ from pathlib import Path
 from typing import Optional
 
 import git
+from ranzen.decorators import implements
 
-from ..algorithm_base import SubprocessAlgorithmMixin
+from ..algorithm_base import Algorithm, SubprocessAlgorithmMixin
 from .in_algorithm import InAlgorithm
 
 __all__ = ["InstalledModel"]
@@ -28,6 +29,7 @@ class InstalledModel(SubprocessAlgorithmMixin, InAlgorithm):
         name: str,
         dir_name: str,
         top_dir: str,
+        is_fairness_algo: bool,
         url: Optional[str] = None,
         executable: Optional[str] = None,
         seed: int = 888,
@@ -61,7 +63,14 @@ class InstalledModel(SubprocessAlgorithmMixin, InAlgorithm):
             self.__executable = str(self._code_path.resolve() / ".venv" / "bin" / "python")
         else:
             self.__executable = executable
-        super().__init__(name=name, seed=seed)
+        self.__name = name
+        self.seed = seed
+        self.is_fairness_algo = is_fairness_algo
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return self.__name
 
     @property
     def _code_path(self) -> Path:

--- a/ethicml/algorithms/inprocess/kamishima.py
+++ b/ethicml/algorithms/inprocess/kamishima.py
@@ -35,6 +35,7 @@ class Kamishima(InstalledModel):
             dir_name="kamishima",
             url="https://github.com/predictive-analytics-lab/kamfadm.git",
             top_dir="kamfadm",
+            is_fairness_algo=True,
         )
         self.eta = eta
         self._fit_info: Optional[_FitInfo] = None

--- a/ethicml/algorithms/inprocess/logistic_regression.py
+++ b/ethicml/algorithms/inprocess/logistic_regression.py
@@ -1,5 +1,5 @@
 """Wrapper around Sci-Kit Learn Logistic Regression."""
-from typing import Optional
+from dataclasses import dataclass, field
 
 import numpy as np
 import pandas as pd
@@ -14,14 +14,18 @@ from .in_algorithm import InAlgorithm
 __all__ = ["LR", "LRCV", "LRProb"]
 
 
+@dataclass
 class LR(InAlgorithm):
     """Logistic regression with hard predictions."""
 
-    def __init__(self, C: Optional[float] = None, seed: int = 888):
-        self.C = LogisticRegression().C if C is None else C
-        super().__init__(
-            name=f"Logistic Regression (C={self.C})", is_fairness_algo=False, seed=seed
-        )
+    C: float = field(default_factory=lambda: LogisticRegression().C)
+    seed: int = 888
+    is_fairness_algo = False
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return f"Logistic Regression (C={self.C})"
 
     @implements(InAlgorithm)
     def fit(self, train: DataTuple) -> InAlgorithm:
@@ -46,14 +50,18 @@ class LR(InAlgorithm):
         return Prediction(hard=pd.Series(clf.predict(test.x)))
 
 
+@dataclass
 class LRProb(InAlgorithm):
     """Logistic regression with soft output."""
 
-    def __init__(self, C: Optional[int] = None, seed: int = 888):
-        self.C = LogisticRegression().C if C is None else C
-        super().__init__(
-            name=f"Logistic Regression Prob (C={self.C})", is_fairness_algo=False, seed=seed
-        )
+    C: float = field(default_factory=lambda: LogisticRegression().C)
+    seed: int = 888
+    is_fairness_algo = False
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return f"Logistic Regression Prob (C={self.C})"
 
     @implements(InAlgorithm)
     def fit(self, train: DataTuple) -> InAlgorithm:
@@ -78,12 +86,18 @@ class LRProb(InAlgorithm):
         return SoftPrediction(soft=pd.Series(clf.predict_proba(test.x)[:, 1]))
 
 
+@dataclass
 class LRCV(InAlgorithm):
     """Kind of a cheap hack for now, but gives a proper cross-valudeted LR."""
 
-    def __init__(self, n_splits: int = 3, seed: int = 888) -> None:
-        super().__init__(name="LRCV", is_fairness_algo=False, seed=seed)
-        self.n_splits = n_splits
+    n_splits: int = 3
+    seed: int = 888
+    is_fairness_algo = False
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "LRCV"
 
     @implements(InAlgorithm)
     def fit(self, train: DataTuple) -> InAlgorithm:

--- a/ethicml/algorithms/inprocess/majority.py
+++ b/ethicml/algorithms/inprocess/majority.py
@@ -17,6 +17,7 @@ class Majority(InAlgorithmDC):
 
     @property
     def name(self) -> str:
+        """Name of the algorithm."""
         return "Majority"
 
     @implements(InAlgorithmDC)

--- a/ethicml/algorithms/inprocess/majority.py
+++ b/ethicml/algorithms/inprocess/majority.py
@@ -1,31 +1,34 @@
 """Simply returns the majority label from the train set."""
+from dataclasses import dataclass
 
 import pandas as pd
 from ranzen import implements
 
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
-from .in_algorithm import InAlgorithm
+from .in_algorithm import InAlgorithmDC
 
 __all__ = ["Majority"]
 
 
-class Majority(InAlgorithm):
+@dataclass
+class Majority(InAlgorithmDC):
     """Simply returns the majority label from the train set."""
 
-    def __init__(self, seed: int = 888) -> None:
-        super().__init__(name="Majority", is_fairness_algo=False, seed=seed)
+    @property
+    def name(self) -> str:
+        return "Majority"
 
-    @implements(InAlgorithm)
-    def fit(self, train: DataTuple) -> InAlgorithm:
+    @implements(InAlgorithmDC)
+    def fit(self, train: DataTuple) -> InAlgorithmDC:
         self.maj = train.y.mode().iloc[0].to_numpy()  # type: ignore[attr-defined]
         return self
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def predict(self, test: TestTuple) -> Prediction:
         return Prediction(hard=pd.Series(self.maj.repeat(len(test.x))))
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
         maj = train.y.mode().iloc[0].to_numpy()  # type: ignore[attr-defined]
         return Prediction(hard=pd.Series(maj.repeat(len(test.x))))

--- a/ethicml/algorithms/inprocess/manual.py
+++ b/ethicml/algorithms/inprocess/manual.py
@@ -7,13 +7,13 @@ from ranzen import implements
 
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
-from .in_algorithm import InAlgorithm
+from .in_algorithm import InAlgorithmDC
 
 __all__ = ["Corels"]
 
 
 @dataclass
-class Corels(InAlgorithm):
+class Corels(InAlgorithmDC):
     """CORELS (Certifiably Optimal RulE ListS) algorithm for the COMPAS dataset.
 
     This algorithm uses if-statements to make predictions. It only works on COMPAS with s as sex.
@@ -21,19 +21,16 @@ class Corels(InAlgorithm):
     From this paper: https://arxiv.org/abs/1704.01701
     """
 
-    seed: int = 888
-    is_fairness_algo = True
-
     @property
     def name(self) -> str:
         """Name of the algorithm."""
         return "CORELS"
 
-    @implements(InAlgorithm)
-    def fit(self, train: DataTuple) -> InAlgorithm:
+    @implements(InAlgorithmDC)
+    def fit(self, train: DataTuple) -> InAlgorithmDC:
         return self
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def predict(self, test: TestTuple) -> Prediction:
         if test.name is None or "Compas" not in test.name or "sex" not in test.s.columns:
             raise RuntimeError("The Corels algorithm only works on the COMPAS dataset")

--- a/ethicml/algorithms/inprocess/manual.py
+++ b/ethicml/algorithms/inprocess/manual.py
@@ -1,4 +1,6 @@
 """Manually specified (i.e. not learned) models."""
+from dataclasses import dataclass
+
 import numpy as np
 import pandas as pd
 from ranzen import implements
@@ -10,6 +12,7 @@ from .in_algorithm import InAlgorithm
 __all__ = ["Corels"]
 
 
+@dataclass
 class Corels(InAlgorithm):
     """CORELS (Certifiably Optimal RulE ListS) algorithm for the COMPAS dataset.
 
@@ -18,9 +21,13 @@ class Corels(InAlgorithm):
     From this paper: https://arxiv.org/abs/1704.01701
     """
 
-    def __init__(self, seed: int = 888) -> None:
-        """Constructor of the class."""
-        super().__init__(name="CORELS", seed=seed)
+    seed: int = 888
+    is_fairness_algo = True
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "CORELS"
 
     @implements(InAlgorithm)
     def fit(self, train: DataTuple) -> InAlgorithm:
@@ -28,20 +35,6 @@ class Corels(InAlgorithm):
 
     @implements(InAlgorithm)
     def predict(self, test: TestTuple) -> Prediction:
-        if test.name is None or "Compas" not in test.name or "sex" not in test.s.columns:
-            raise RuntimeError("The Corels algorithm only works on the COMPAS dataset")
-        age = test.x["age-num"].to_numpy()
-        priors = test.x["priors-count"].to_numpy()
-        sex = test.s["sex"].to_numpy()
-        male = 1
-        condition1 = (age >= 18) & (age <= 20) & (sex == male)
-        condition2 = (age >= 21) & (age <= 23) & (priors >= 2) & (priors <= 3)
-        condition3: np.ndarray = priors > 3
-        pred = np.where(condition1 | condition2 | condition3, np.ones_like(age), np.zeros_like(age))
-        return Prediction(hard=pd.Series(pred))
-
-    @implements(InAlgorithm)
-    def run(self, _: DataTuple, test: TestTuple) -> Prediction:
         if test.name is None or "Compas" not in test.name or "sex" not in test.s.columns:
             raise RuntimeError("The Corels algorithm only works on the COMPAS dataset")
         age = test.x["age-num"].to_numpy()

--- a/ethicml/algorithms/inprocess/mlp.py
+++ b/ethicml/algorithms/inprocess/mlp.py
@@ -24,8 +24,6 @@ ACTIVATIONS: Dict[str, ActivationType] = {
 class MLP(InAlgorithm):
     """Multi-layer Perceptron."""
 
-    is_fairness_algo = False
-
     def __init__(
         self,
         hidden_layer_sizes: Optional[Tuple[int, ...]] = None,

--- a/ethicml/algorithms/inprocess/mlp.py
+++ b/ethicml/algorithms/inprocess/mlp.py
@@ -24,13 +24,16 @@ ACTIVATIONS: Dict[str, ActivationType] = {
 class MLP(InAlgorithm):
     """Multi-layer Perceptron."""
 
+    is_fairness_algo = False
+
     def __init__(
         self,
-        hidden_layer_sizes: Optional[Tuple[int]] = None,
+        hidden_layer_sizes: Optional[Tuple[int, ...]] = None,
         activation: Optional[ActivationType] = None,
         seed: int = 888,
     ):
-        super().__init__(name="MLP", is_fairness_algo=False, seed=seed)
+        self.is_fairness_algo = False
+        self.seed = seed
         if hidden_layer_sizes is None:
             self.hidden_layer_sizes = MLPClassifier().hidden_layer_sizes
         else:
@@ -38,6 +41,11 @@ class MLP(InAlgorithm):
         self.activation: ActivationType = (
             MLPClassifier().activation if activation is None else activation
         )
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "MLP"
 
     @implements(InAlgorithm)
     def fit(self, train: DataTuple) -> InAlgorithm:
@@ -49,15 +57,9 @@ class MLP(InAlgorithm):
     def predict(self, test: TestTuple) -> Prediction:
         return Prediction(hard=pd.Series(self.clf.predict(test.x)))
 
-    @implements(InAlgorithm)
-    def run(self, train: DataTuple, test: TestTuple) -> Prediction:
-        clf = select_mlp(self.hidden_layer_sizes, self.activation, seed=self.seed)
-        clf.fit(train.x, train.y.to_numpy().ravel())
-        return Prediction(hard=pd.Series(clf.predict(test.x)))
-
 
 def select_mlp(
-    hidden_layer_sizes: Tuple[int], activation: ActivationType, seed: int
+    hidden_layer_sizes: Tuple[int, ...], activation: ActivationType, seed: int
 ) -> MLPClassifier:
     """Create MLP model for the given parameters."""
     assert activation in ACTIVATIONS

--- a/ethicml/algorithms/inprocess/oracle.py
+++ b/ethicml/algorithms/inprocess/oracle.py
@@ -1,15 +1,18 @@
 """How would a perfect predictor perform?"""
+from dataclasses import dataclass
+
 from ranzen import implements
 
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 from ..postprocess.dp_flip import DPFlip
-from .in_algorithm import InAlgorithm
+from .in_algorithm import InAlgorithm, InAlgorithmDC
 
 __all__ = ["Oracle", "DPOracle"]
 
 
-class Oracle(InAlgorithm):
+@dataclass
+class Oracle(InAlgorithmDC):
     """A perfect predictor.
 
     Can only be used if test is a DataTuple, rather than the usual TestTuple.
@@ -17,25 +20,27 @@ class Oracle(InAlgorithm):
     but can be useful if you want to either do a sanity check, or report potential values.
     """
 
-    def __init__(self, seed: int = 888) -> None:
-        super().__init__(name="Oracle", is_fairness_algo=False, seed=seed)
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "Oracle"
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def fit(self, train: DataTuple) -> InAlgorithm:
         return self
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def predict(self, test: TestTuple) -> Prediction:
         assert isinstance(test, DataTuple), "test must be a DataTuple."
         return Prediction(hard=test.y[test.y.columns[0]].copy())
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
         assert isinstance(test, DataTuple), "test must be a DataTuple."
         return Prediction(hard=test.y[test.y.columns[0]].copy())
 
 
-class DPOracle(InAlgorithm):
+class DPOracle(InAlgorithmDC):
     """A perfect Demographic Parity Predictor.
 
     Can only be used if test is a DataTuple, rather than the usual TestTuple.
@@ -43,21 +48,23 @@ class DPOracle(InAlgorithm):
     but can be useful if you want to either do a sanity check, or report potential values.
     """
 
-    def __init__(self, seed: int = 888) -> None:
-        super().__init__(name="DemPar. Oracle", is_fairness_algo=True, seed=seed)
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "DemPar. Oracle"
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def fit(self, train: DataTuple) -> InAlgorithm:
         return self
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def predict(self, test: TestTuple) -> Prediction:
         assert isinstance(test, DataTuple), "test must be a DataTuple."
         flipper = DPFlip(seed=self.seed)
         test_preds = Prediction(test.y[test.y.columns[0]].copy())
         return flipper.run(test_preds, test, test_preds, test)
 
-    @implements(InAlgorithm)
+    @implements(InAlgorithmDC)
     def run(self, train: DataTuple, test: TestTuple) -> Prediction:
         assert isinstance(test, DataTuple), "test must be a DataTuple."
         flipper = DPFlip(seed=self.seed)

--- a/ethicml/algorithms/inprocess/svm.py
+++ b/ethicml/algorithms/inprocess/svm.py
@@ -16,11 +16,19 @@ __all__ = ["SVM"]
 class SVM(InAlgorithm):
     """Support Vector Machine."""
 
+    is_fairness_algo = False
+
     def __init__(self, C: Optional[float] = None, kernel: Optional[str] = None, seed: int = 888):
         kernel_name = f" ({kernel})" if kernel is not None else ""
-        super().__init__(name="SVM" + kernel_name, is_fairness_algo=False, seed=seed)
+        self.__name = "SVM" + kernel_name
+        self.seed = seed
         self.C = SVC().C if C is None else C
         self.kernel = SVC().kernel if kernel is None else kernel
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return self.__name
 
     @implements(InAlgorithm)
     def fit(self, train: DataTuple) -> InAlgorithm:
@@ -31,12 +39,6 @@ class SVM(InAlgorithm):
     @implements(InAlgorithm)
     def predict(self, test: TestTuple) -> Prediction:
         return Prediction(hard=pd.Series(self.clf.predict(test.x)))
-
-    @implements(InAlgorithm)
-    def run(self, train: DataTuple, test: Union[DataTuple, TestTuple]) -> Prediction:
-        clf = select_svm(self.C, self.kernel, self.seed)
-        clf.fit(train.x, train.y.to_numpy().ravel())
-        return Prediction(hard=pd.Series(clf.predict(test.x)))
 
 
 def select_svm(C: float, kernel: str, seed: int) -> Union[LinearSVC, SVC]:

--- a/ethicml/algorithms/inprocess/zafar.py
+++ b/ethicml/algorithms/inprocess/zafar.py
@@ -28,13 +28,14 @@ class FitParams(NamedTuple):
 
 
 class _ZafarAlgorithmBase(InstalledModel):
-    def __init__(self, name: str, sub_dir: Path):
+    def __init__(self, name: str, sub_dir: Path, is_fairness_algo: bool):
         super().__init__(
             name=name,
             dir_name="zafar",
             url="https://github.com/predictive-analytics-lab/fair-classification.git",
             top_dir="fair-classification",
             use_poetry=True,
+            is_fairness_algo=is_fairness_algo,
         )
         self._sub_dir = sub_dir
         self._fit_params: Optional[FitParams] = None
@@ -115,7 +116,7 @@ class ZafarBaseline(_ZafarAlgorithmBase):
     """Zafar without fairness."""
 
     def __init__(self) -> None:
-        super().__init__(name="ZafarBaseline", sub_dir=SUB_DIR_IMPACT)
+        super().__init__(name="ZafarBaseline", sub_dir=SUB_DIR_IMPACT, is_fairness_algo=False)
 
     @implements(_ZafarAlgorithmBase)
     def _get_fit_cmd(self, train_name: str, model_path: str) -> List[str]:
@@ -126,7 +127,9 @@ class ZafarAccuracy(_ZafarAlgorithmBase):
     """Zafar with fairness."""
 
     def __init__(self, gamma: float = 0.5):
-        super().__init__(name=f"ZafarAccuracy, γ={gamma}", sub_dir=SUB_DIR_IMPACT)
+        super().__init__(
+            name=f"ZafarAccuracy, γ={gamma}", sub_dir=SUB_DIR_IMPACT, is_fairness_algo=True
+        )
         self.gamma = gamma
 
     @implements(_ZafarAlgorithmBase)
@@ -138,7 +141,9 @@ class ZafarFairness(_ZafarAlgorithmBase):
     """Zafar with fairness."""
 
     def __init__(self, c: float = 0.001):
-        super().__init__(name=f"ZafarFairness, c={c}", sub_dir=SUB_DIR_IMPACT)
+        super().__init__(
+            name=f"ZafarFairness, c={c}", sub_dir=SUB_DIR_IMPACT, is_fairness_algo=True
+        )
         self._c = c
 
     @implements(_ZafarAlgorithmBase)
@@ -153,7 +158,8 @@ class ZafarEqOpp(_ZafarAlgorithmBase):
     _base_name: ClassVar[str] = "ZafarEqOpp"
 
     def __init__(self, tau: float = 5.0, mu: float = 1.2, eps: float = 0.0001):
-        super().__init__(name=f"{self._base_name}, τ={tau}, μ={mu}", sub_dir=SUB_DIR_MISTREAT)
+        name = f"{self._base_name}, τ={tau}, μ={mu}"
+        super().__init__(name=name, sub_dir=SUB_DIR_MISTREAT, is_fairness_algo=True)
         self._tau = tau
         self._mu = mu
         self._eps = eps

--- a/ethicml/algorithms/postprocess/dp_flip.py
+++ b/ethicml/algorithms/postprocess/dp_flip.py
@@ -1,4 +1,5 @@
 """Demographic Parity Label flipping approach."""
+from dataclasses import dataclass
 from typing import Tuple
 
 import numpy as np
@@ -7,22 +8,25 @@ from ranzen import implements
 
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
-from .post_algorithm import PostAlgorithm
+from .post_algorithm import PostAlgorithmDC
 
 __all__ = ["DPFlip"]
 
 
-class DPFlip(PostAlgorithm):
+@dataclass
+class DPFlip(PostAlgorithmDC):
     """Randomly flip a number of decisions such that perfect demographic parity is achieved."""
 
-    def __init__(self, seed: int = 888) -> None:
-        super().__init__(name="DemPar. Post Process", seed=seed)
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "DemPar. Post Process"
 
-    @implements(PostAlgorithm)
-    def fit(self, train_predictions: Prediction, train: DataTuple) -> PostAlgorithm:
+    @implements(PostAlgorithmDC)
+    def fit(self, train_predictions: Prediction, train: DataTuple) -> "DPFlip":
         return self
 
-    @implements(PostAlgorithm)
+    @implements(PostAlgorithmDC)
     def predict(self, test_predictions: Prediction, test: TestTuple) -> Prediction:
         x, y = self._fit(test, test_predictions)
         _test_preds = self._flip(
@@ -32,7 +36,7 @@ class DPFlip(PostAlgorithm):
             _test_preds, test, flip_0_to_1=False, num_to_flip=y, s_group=1, seed=self.seed
         )
 
-    @implements(PostAlgorithm)
+    @implements(PostAlgorithmDC)
     def run(
         self,
         train_predictions: Prediction,

--- a/ethicml/algorithms/postprocess/hardt.py
+++ b/ethicml/algorithms/postprocess/hardt.py
@@ -19,10 +19,16 @@ class Hardt(PostAlgorithm):
     """Post-processing method by Hardt et al."""
 
     def __init__(self, unfavorable_label: int = 0, favorable_label: int = 1, seed: int = 888):
-        super().__init__(name="Hardt", seed=seed)
+        self.seed = seed
+        self.is_fairness_algo = True
         self._unfavorable_label = unfavorable_label
         self._favorable_label = favorable_label
         self._random = RandomState(seed=self.seed)
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "Hardt"
 
     @implements(PostAlgorithm)
     def fit(self, train_predictions: Prediction, train: DataTuple) -> PostAlgorithm:

--- a/ethicml/algorithms/postprocess/post_algorithm.py
+++ b/ethicml/algorithms/postprocess/post_algorithm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import TypeVar
-from typing_extensions import Protocol
+from typing_extensions import Protocol, runtime_checkable
 
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
@@ -15,6 +15,7 @@ __all__ = ["PostAlgorithm", "PostAlgorithmDC"]
 _PA = TypeVar("_PA", bound="PostAlgorithm")
 
 
+@runtime_checkable
 class PostAlgorithm(Algorithm, Protocol):
     """Abstract Base Class for all algorithms that do post-processing."""
 

--- a/ethicml/algorithms/postprocess/post_algorithm.py
+++ b/ethicml/algorithms/postprocess/post_algorithm.py
@@ -2,19 +2,24 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from dataclasses import dataclass
+from typing import TypeVar
+from typing_extensions import Protocol
 
 from ethicml.utility import DataTuple, Prediction, TestTuple
 
 from ..algorithm_base import Algorithm
 
-__all__ = ["PostAlgorithm"]
+__all__ = ["PostAlgorithm", "PostAlgorithmDC"]
+
+_PA = TypeVar("_PA", bound="PostAlgorithm")
 
 
-class PostAlgorithm(Algorithm):
+class PostAlgorithm(Algorithm, Protocol):
     """Abstract Base Class for all algorithms that do post-processing."""
 
     @abstractmethod
-    def fit(self, train_predictions: Prediction, train: DataTuple) -> PostAlgorithm:
+    def fit(self: _PA, train_predictions: Prediction, train: DataTuple) -> _PA:
         """Run Algorithm on the given data.
 
         Args:
@@ -35,7 +40,6 @@ class PostAlgorithm(Algorithm):
             predictions
         """
 
-    @abstractmethod
     def run(
         self,
         train_predictions: Prediction,
@@ -54,3 +58,13 @@ class PostAlgorithm(Algorithm):
         Returns:
             post-processed predictions on the test set
         """
+        self.fit(train_predictions, train)
+        return self.predict(test_predictions, test)
+
+
+@dataclass  # type: ignore  # mypy doesn't allow abstract dataclasses because mypy is stupid
+class PostAlgorithmDC(PostAlgorithm):
+    """PostAlgorithm dataclass base class."""
+
+    is_fairness_algo = True
+    seed: int = 888

--- a/ethicml/algorithms/preprocess/beutel.py
+++ b/ethicml/algorithms/preprocess/beutel.py
@@ -19,6 +19,7 @@ class Beutel(PreAlgorithmAsync):
         self,
         dir: Union[str, Path],
         fairness: FairnessType = "DP",
+        *,
         enc_size: Sequence[int] = (40,),
         adv_size: Sequence[int] = (40,),
         pred_size: Sequence[int] = (40,),
@@ -32,8 +33,8 @@ class Beutel(PreAlgorithmAsync):
         validation_pcnt: float = 0.1,
         seed: int = 888,
     ):
-        # pylint: disable=too-many-arguments
-        super().__init__(name=f"Beutel {fairness}", seed=seed, out_size=enc_size[-1])
+        self.seed = seed
+        self._out_size = enc_size[-1]
         self.model_dir = dir if isinstance(dir, Path) else Path(dir)
         self.flags: Dict[str, Union[str, Sequence[int], int, float]] = {
             "fairness": fairness,
@@ -50,6 +51,11 @@ class Beutel(PreAlgorithmAsync):
             "validation_pcnt": validation_pcnt,
             "seed": seed,
         }
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return f"Beutel {self.flags['fairness']}"
 
     @implements(PreAlgorithmAsync)
     def _run_script_command(

--- a/ethicml/algorithms/preprocess/calders.py
+++ b/ethicml/algorithms/preprocess/calders.py
@@ -1,5 +1,5 @@
 """Kamiran&Calders 2012, massaging."""
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from ranzen import implements
 
@@ -15,9 +15,15 @@ class Calders(PreAlgorithm):
     """Massaging algorithm from Kamiran&Calders 2012."""
 
     def __init__(self, preferable_class: int, disadvantaged_group: int, seed: int = 888):
-        super().__init__(name="Calders", seed=seed, out_size=None)
+        self.seed = seed
+        self._out_size: Optional[int] = None
         self.preferable_class = preferable_class
         self.disadvantaged_group = disadvantaged_group
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "Calders"
 
     @implements(PreAlgorithm)
     def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -1,43 +1,34 @@
 """Abstract Base Class of all algorithms in the framework."""
-
 from __future__ import annotations
 
 from abc import abstractmethod
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Optional, Tuple, TypeVar
+from typing_extensions import Protocol, runtime_checkable
 
 from ranzen import implements
 
 from ethicml.algorithms.algorithm_base import Algorithm, SubprocessAlgorithmMixin
 from ethicml.utility import DataTuple, TestTuple
 
-__all__ = ["PreAlgorithm", "PreAlgorithmAsync"]
+__all__ = ["PreAlgorithm", "PreAlgorithmAsync", "PreAlgorithmDC"]
 
 T = TypeVar("T", DataTuple, TestTuple)
 
 
-class PreAlgorithm(Algorithm):
+@runtime_checkable
+class PreAlgorithm(Algorithm, Protocol):
     """Abstract Base Class for all algorithms that do pre-processing."""
 
-    def __init__(self, name: str, seed: int, out_size: Optional[int]):
-        """Base constructor for the Algorithm class.
-
-        Args:
-            name: name of the algorithm
-            seed: seed for the random number generator
-            out_size: number of features to generate
-        """
-        super().__init__(name=name, seed=seed)
-        self._out_size = out_size
+    _out_size: Optional[int]
 
     @abstractmethod
     def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
-        """Generate fair features with the given data.
+        """Fit transformer on the given data.
 
         Args:
             train: training data
-            test: test data
 
         Returns:
             a tuple of the pre-processed training data and the test data
@@ -79,8 +70,19 @@ class PreAlgorithm(Algorithm):
         return self._out_size
 
 
-class PreAlgorithmAsync(SubprocessAlgorithmMixin, PreAlgorithm):
+@dataclass  # type: ignore  # mypy doesn't allow abstract dataclasses because mypy is stupid
+class PreAlgorithmDC(PreAlgorithm):
+    """PreAlgorithm dataclass base class."""
+
+    _out_size = None  # this is not a dataclass field and so it must not have a type annotation
+    is_fairness_algo = True
+    seed: int = 888
+
+
+class PreAlgorithmAsync(SubprocessAlgorithmMixin, PreAlgorithm, Protocol):
     """Pre-Algorithm that can be run blocking and asynchronously."""
+
+    model_dir: Path
 
     @implements(PreAlgorithm)
     def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
@@ -93,7 +95,6 @@ class PreAlgorithmAsync(SubprocessAlgorithmMixin, PreAlgorithm):
         Returns:
             a tuple of the pre-processed training data and the test data
         """
-        self.model_path = self.model_dir / f"model_{self.name}.joblib"
         with TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             # ================================ write data to files ================================
@@ -102,7 +103,7 @@ class PreAlgorithmAsync(SubprocessAlgorithmMixin, PreAlgorithm):
 
             # ========================== generate commandline arguments ===========================
             transformed_train_path = tmp_path / "transformed_train.npz"
-            cmd = self._fit_script_command(train_path, transformed_train_path, self.model_path)
+            cmd = self._fit_script_command(train_path, transformed_train_path, self._model_path)
 
             # ============================= run the generated command =============================
             self._call_script(cmd + ["--mode", "fit"])
@@ -136,7 +137,9 @@ class PreAlgorithmAsync(SubprocessAlgorithmMixin, PreAlgorithm):
             # ========================== generate commandline arguments ===========================
             transformed_test_path = tmp_path / "transformed_test.npz"
             cmd = self._transform_script_command(
-                model_path=self.model_path, test_path=test_path, new_test_path=transformed_test_path
+                model_path=self._model_path,
+                test_path=test_path,
+                new_test_path=transformed_test_path,
             )
 
             # ============================= run the generated command =============================
@@ -191,6 +194,10 @@ class PreAlgorithmAsync(SubprocessAlgorithmMixin, PreAlgorithm):
             name=None if test.name is None else f"{self.name}: {test.name}"
         )
         return transformed_train, transformed_test
+
+    @property
+    def _model_path(self) -> Path:
+        return self.model_dir / f"model_{self.name}.joblib"
 
     @abstractmethod
     def _run_script_command(

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -15,6 +15,7 @@ from ethicml.utility import DataTuple, TestTuple
 __all__ = ["PreAlgorithm", "PreAlgorithmAsync", "PreAlgorithmDC"]
 
 T = TypeVar("T", DataTuple, TestTuple)
+_PA = TypeVar("_PA", bound="PreAlgorithm")
 
 
 @runtime_checkable
@@ -24,7 +25,7 @@ class PreAlgorithm(Algorithm, Protocol):
     _out_size: Optional[int]
 
     @abstractmethod
-    def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
+    def fit(self: _PA, train: DataTuple) -> Tuple[_PA, DataTuple]:
         """Fit transformer on the given data.
 
         Args:

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Optional, Tuple, TypeVar

--- a/ethicml/algorithms/preprocess/upsampler.py
+++ b/ethicml/algorithms/preprocess/upsampler.py
@@ -1,5 +1,6 @@
 """Simple upsampler that makes subgroups the same size as the majority group."""
 import itertools
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 from typing_extensions import Literal
 
@@ -14,6 +15,7 @@ from .pre_algorithm import PreAlgorithm, T
 __all__ = ["Upsampler"]
 
 
+@dataclass
 class Upsampler(PreAlgorithm):
     """Upsampler algorithm.
 
@@ -21,16 +23,20 @@ class Upsampler(PreAlgorithm):
     of samples.
     """
 
-    def __init__(
-        self, strategy: Literal["uniform", "preferential", "naive"] = "uniform", seed: int = 888
-    ):
-        super().__init__(name=f"Upsample {strategy}", seed=seed, out_size=None)
+    strategy: Literal["uniform", "preferential", "naive"] = "uniform"
+    seed: int = 888
+    is_fairness_algo = True
 
-        assert strategy in ["uniform", "preferential", "naive"]
-        self.strategy = strategy
+    def __post_init__(self) -> None:
+        assert self.strategy in ["uniform", "preferential", "naive"]
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return f"Upsample {self.strategy}"
 
     @implements(PreAlgorithm)
-    def fit(self, train: DataTuple) -> Tuple[PreAlgorithm, DataTuple]:
+    def fit(self, train: DataTuple) -> Tuple["Upsampler", DataTuple]:
         self._out_size = train.x.shape[1]
         new_train, _ = upsample(train, train, self.strategy, self.seed, name=self.name)
         return self, new_train

--- a/ethicml/algorithms/preprocess/vfae.py
+++ b/ethicml/algorithms/preprocess/vfae.py
@@ -17,6 +17,7 @@ class VFAE(PreAlgorithmAsync):
         self,
         dir: Union[str, Path],
         dataset: str,
+        *,
         supervised: bool = True,
         epochs: int = 10,
         batch_size: int = 32,
@@ -27,8 +28,8 @@ class VFAE(PreAlgorithmAsync):
         z1_dec_size: Optional[List[int]] = None,
         seed: int = 888,
     ):
-        # pylint: disable=too-many-arguments
-        super().__init__(name="VFAE", seed=seed, out_size=latent_dims)
+        self.seed = seed
+        self._out_size = latent_dims
         self.model_dir = dir if isinstance(dir, Path) else Path(dir)
 
         if z1_enc_size is None:
@@ -50,6 +51,11 @@ class VFAE(PreAlgorithmAsync):
             "z1_dec_size": z1_dec_size,
             "seed": seed,
         }
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "VFAE"
 
     @implements(PreAlgorithmAsync)
     def _run_script_command(

--- a/ethicml/algorithms/preprocess/zemel.py
+++ b/ethicml/algorithms/preprocess/zemel.py
@@ -1,6 +1,6 @@
 """Zemel's Learned Fair Representations."""
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from ranzen import implements
 
@@ -28,7 +28,8 @@ class Zemel(PreAlgorithmAsync):
         epsilon: float = 1e-5,
         seed: int = 888,
     ) -> None:
-        super().__init__(name="Zemel", seed=seed, out_size=None)
+        self.seed = seed
+        self._out_size: Optional[int] = None
         self.model_dir = dir if isinstance(dir, Path) else Path(dir)
         self.flags: Dict[str, Union[int, float]] = {
             "clusters": clusters,
@@ -41,6 +42,11 @@ class Zemel(PreAlgorithmAsync):
             "threshold": threshold,
             "seed": seed,
         }
+
+    @property
+    def name(self) -> str:
+        """Name of the algorithm."""
+        return "Zemel"
 
     @implements(PreAlgorithm)
     def run(self, train: DataTuple, test: TestTuple) -> Tuple[DataTuple, TestTuple]:

--- a/ethicml/evaluators/parallelism.py
+++ b/ethicml/evaluators/parallelism.py
@@ -47,6 +47,8 @@ def run_in_parallel(
     """
     if not algos or not data:
         return cast(List[List[Prediction]], [[]])
+    # The following isinstance check is not at all reliable because `InAlgorithm` is a Protocol,
+    # but that's completely fine because this check is only here for mypy anyway.
     if isinstance(algos[0], InAlgorithm):
         in_algos = cast(Sequence[InAlgorithm], algos)
         return arrange_in_parallel(algos=in_algos, data=data, num_cpus=num_cpus)

--- a/ethicml/implementations/pytorch_common.py
+++ b/ethicml/implementations/pytorch_common.py
@@ -90,7 +90,7 @@ def quadratic_time_mmd(x: Tensor, y: Tensor, sigma: float) -> Tensor:
     def pad_second(x: Tensor) -> Tensor:
         return torch.unsqueeze(x, 1)
 
-    gamma = 1 / (2 * sigma ** 2)
+    gamma = 1 / (2 * sigma**2)
     # use the second binomial formula
     kernel_xx = torch.exp(-gamma * (-2 * xx_gm + pad_second(x_sqnorms) + pad_first(x_sqnorms)))
     kernel_xy = torch.exp(-gamma * (-2 * xy_gm + pad_second(x_sqnorms) + pad_first(y_sqnorms)))

--- a/ethicml/metrics/dependence_measures.py
+++ b/ethicml/metrics/dependence_measures.py
@@ -90,7 +90,7 @@ class Yanovich(_DependenceMeasure):
                     # k < l
                     for l in range(k + 1, len(y_vals)):
                         determinant = joint[i, k] * joint[j, l] - joint[j, k] * joint[i, l]
-                        sum_sq_determinants += determinant ** 2
+                        sum_sq_determinants += determinant**2
 
         marginal = np.sum(joint, axis=1)
 

--- a/ethicml/metrics/hsic.py
+++ b/ethicml/metrics/hsic.py
@@ -27,8 +27,8 @@ def hsic(
     def exp_c(x: np.ndarray) -> np.ndarray:
         return np.expand_dims(x, 1)
 
-    gamma_first = 1.0 / (2 * sigma_first ** 2)
-    gamma_second = 1.0 / (2 * sigma_second ** 2)
+    gamma_first = 1.0 / (2 * sigma_first**2)
+    gamma_second = 1.0 / (2 * sigma_second**2)
     # use the second binomial formula
     kernel_xx = np.exp(-gamma_first * (-2 * xx_gram + exp_c(x_sqnorms) + exp_r(x_sqnorms)))
     kernel_yy = np.exp(-gamma_second * (-2 * yy_gram + exp_c(y_sqnorms) + exp_r(y_sqnorms)))

--- a/ethicml/vision/data/transforms.py
+++ b/ethicml/vision/data/transforms.py
@@ -38,7 +38,7 @@ class NoisyDequantize(Transformation):
 
     def __init__(self, n_bits_x: int = 8):
         """Createca NoisyQuantize object."""
-        self.n_bins = 2 ** n_bits_x
+        self.n_bins = 2**n_bits_x
 
     def _transform(self, data: Tensor) -> Tensor:
         return torch.clamp(data + (torch.rand_like(data) / self.n_bins), min=0, max=1)
@@ -50,7 +50,7 @@ class Quantize(Transformation):
     def __init__(self, n_bits_x: int = 8):
         """Create Quantize object."""
         self.n_bits_x = n_bits_x
-        self.n_bins = 2 ** n_bits_x
+        self.n_bins = 2**n_bits_x
 
     def _transform(self, x: Tensor) -> Tensor:
         if self.n_bits_x < 8:

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,5 @@
 {
+  "pythonVersion": "3.7",
   "reportMissingTypeStubs": "none",
   "reportUnknownParameterType": "none",
   "reportUnknownArgumentType": "none",

--- a/tests/models_test/inprocess_test/models_inprocessing_test.py
+++ b/tests/models_test/inprocess_test/models_inprocessing_test.py
@@ -191,7 +191,13 @@ def test_local_installed_lr(toy_train_test: TrainTestPair):
 
     class _LocalInstalledLR(InAlgorithmAsync):
         def __init__(self):
-            super().__init__(name="local installed LR", seed=0, is_fairness_algo=False)
+            self.seed = 0
+            self.is_fairness_algo = False
+            self.model_dir = Path(".")
+
+        @property
+        def name(self) -> str:
+            return "local installed LR"
 
         @implements(InAlgorithmAsync)
         def _run_script_command(

--- a/tests/saving_data_test.py
+++ b/tests/saving_data_test.py
@@ -31,7 +31,13 @@ def test_simple_saving() -> None:
         """Dummy algorithm class for testing whether writing and reading feather files works."""
 
         def __init__(self) -> None:
-            super().__init__(name="Check equality", seed=-1)
+            self.seed = -1
+            self.is_fairness_algo = False
+            self.model_dir = Path(".")
+
+        @property
+        def name(self) -> str:
+            return "Check equality"
 
         def _run_script_command(self, train_path, test_path, pred_path):
             """Check if the dataframes loaded from the files are the same as the original ones."""


### PR DESCRIPTION
The goal is to be able to use dataclasses for the algorithm classes. Instead of Abstract Base Classes the algorithm base classes are now Protocols. The reason for that is that protocols allow "abstract" attributes (that is attributes that the child class must supply). I already converted some of the algorithms to dataclasses.
