### PR TITLE
add guard that ci workflow passes successfully

### DIFF
--- a/.github/workflows/dependabot_auto.yml
+++ b/.github/workflows/dependabot_auto.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dependabot-auto-approve:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -27,7 +27,7 @@ jobs:
   dependabot-auto-merge:
     needs: [dependabot-auto-approve]
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
I'm tempted to make the workflow dir trigger the dummy CI rather than the real one