### PR TITLE
Add aliases for dataset splits within the dataset classes

### DIFF
--- a/ethicml/data/tabular_data/admissions.py
+++ b/ethicml/data/tabular_data/admissions.py
@@ -39,7 +39,7 @@ We replace the mean GPA with a binary label Y representing whether the studentâ€
 """
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import ClassVar, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import flatten_dict
@@ -73,6 +73,9 @@ class Admissions(LoadableDataset):
     """UFRGS Admissions dataset."""
 
     split: AdmissionsSplits = AdmissionsSplits.GENDER
+
+    Splits: ClassVar[Type[AdmissionsSplits]] = AdmissionsSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
 
     def __post_init__(self) -> None:
         disc_feature_groups = {"gender": ["gender"], "gpa": ["gpa"]}

--- a/ethicml/data/tabular_data/adult.py
+++ b/ethicml/data/tabular_data/adult.py
@@ -1,7 +1,7 @@
 """Class to describe features of the Adult dataset."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import ClassVar, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import LabelSpec, flatten_dict, reduce_feature_group, simple_spec
@@ -49,7 +49,10 @@ def adult(
 class Adult(LoadableDataset):
     """UCI Adult dataset."""
 
-    split: AdultSplits = AdultSplits.SEX
+    Splits: ClassVar[Type[AdultSplits]] = AdultSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
+
+    split: AdultSplits = Splits.SEX
     binarize_nationality: bool = False
     binarize_race: bool = False
 

--- a/ethicml/data/tabular_data/compas.py
+++ b/ethicml/data/tabular_data/compas.py
@@ -1,7 +1,7 @@
 """Class to describe features of the Compas dataset."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import ClassVar, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import LabelSpec, flatten_dict, simple_spec
@@ -37,6 +37,9 @@ class Compas(LoadableDataset):
     """Compas (or ProPublica) dataset."""
 
     split: CompasSplits = CompasSplits.SEX
+
+    Splits: ClassVar[Type[CompasSplits]] = CompasSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
 
     def __post_init__(self) -> None:
         disc_feature_groups = {

--- a/ethicml/data/tabular_data/credit.py
+++ b/ethicml/data/tabular_data/credit.py
@@ -1,7 +1,7 @@
 """Class to describe features of the UCI Credit dataset."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import ClassVar, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import flatten_dict
@@ -35,6 +35,9 @@ class Credit(LoadableDataset):
     """UCI Credit Card dataset."""
 
     split: CreditSplits = CreditSplits.SEX
+
+    Splits: ClassVar[Type[CreditSplits]] = CreditSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
 
     def __post_init__(self) -> None:
         disc_feature_groups = {

--- a/ethicml/data/tabular_data/crime.py
+++ b/ethicml/data/tabular_data/crime.py
@@ -1,7 +1,7 @@
 """Class to describe features of the Communities and Crime dataset."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import ClassVar, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import flatten_dict
@@ -35,6 +35,9 @@ class Crime(LoadableDataset):
     """UCI Communities and Crime dataset."""
 
     split: CrimeSplits = CrimeSplits.RACE_BINARY
+
+    Splits: ClassVar[Type[CrimeSplits]] = CrimeSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
 
     def __post_init__(self) -> None:
         disc_feature_groups = {

--- a/ethicml/data/tabular_data/german.py
+++ b/ethicml/data/tabular_data/german.py
@@ -1,7 +1,7 @@
 """Class to describe features of the German dataset."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import ClassVar, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import flatten_dict
@@ -35,6 +35,9 @@ class German(LoadableDataset):
     """German credit dataset."""
 
     split: GermanSplits = GermanSplits.SEX
+
+    Splits: ClassVar[Type[GermanSplits]] = GermanSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
 
     def __post_init__(self) -> None:
         disc_feature_groups = {

--- a/ethicml/data/tabular_data/health.py
+++ b/ethicml/data/tabular_data/health.py
@@ -1,7 +1,7 @@
 """Class to describe features of the Heritage Health dataset."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import ClassVar, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import flatten_dict
@@ -35,6 +35,9 @@ class Health(LoadableDataset):
     """Heritage Health dataset."""
 
     split: HealthSplits = HealthSplits.SEX
+
+    Splits: ClassVar[Type[HealthSplits]] = HealthSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
 
     def __post_init__(self) -> None:
         disc_feature_groups = {

--- a/ethicml/data/tabular_data/law.py
+++ b/ethicml/data/tabular_data/law.py
@@ -19,7 +19,7 @@ Link to repo: https://github.com/mkusner/counterfactual-fairness/
 """
 from dataclasses import dataclass
 from enum import Enum
-from typing import Mapping, Union
+from typing import ClassVar, Mapping, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import LabelGroup, flatten_dict, simple_spec
@@ -55,6 +55,9 @@ class Law(LoadableDataset):
     """LSAC Law School dataset."""
 
     split: LawSplits = LawSplits.SEX
+
+    Splits: ClassVar[Type[LawSplits]] = LawSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
 
     def __post_init__(self) -> None:
         disc_feature_groups = {

--- a/ethicml/data/tabular_data/sqf.py
+++ b/ethicml/data/tabular_data/sqf.py
@@ -1,7 +1,7 @@
 """Class to describe features of the SQF dataset."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import ClassVar, Type, Union
 
 from ..dataset import LoadableDataset
 from ..util import LabelSpec, flatten_dict, simple_spec
@@ -40,6 +40,9 @@ class Sqf(LoadableDataset):
     """
 
     split: SqfSplits = SqfSplits.SEX
+
+    Splits: ClassVar[Type[SqfSplits]] = SqfSplits
+    """Shorthand for the Enum that defines the splits associated with this class."""
 
     def __post_init__(self) -> None:
         disc_feature_groups = {

--- a/tests/data_omegaconf_test.py
+++ b/tests/data_omegaconf_test.py
@@ -10,16 +10,16 @@ import ethicml as em
 @pytest.mark.parametrize(
     "data_class,value,should_pass",
     [
-        (em.Admissions, em.AdmissionsSplits.GENDER, True),
+        (em.Admissions, em.Admissions.Splits.GENDER, True),
         (em.Adult, "Race", False),
-        (em.Adult, em.AdultSplits.RACE, True),
-        (em.Compas, em.CompasSplits.RACE_SEX, True),
-        (em.Credit, em.CreditSplits.SEX, True),
-        (em.Crime, em.CrimeSplits.RACE_BINARY, True),
-        (em.German, em.GermanSplits.SEX, True),
-        (em.Health, em.HealthSplits.SEX, True),
-        (em.Law, em.LawSplits.SEX, True),
-        (em.Sqf, em.SqfSplits.RACE_SEX, True),
+        (em.Adult, em.Adult.Splits.RACE, True),
+        (em.Compas, em.Compas.Splits.RACE_SEX, True),
+        (em.Credit, em.Credit.Splits.SEX, True),
+        (em.Crime, em.Crime.Splits.RACE_BINARY, True),
+        (em.German, em.German.Splits.SEX, True),
+        (em.Health, em.Health.Splits.SEX, True),
+        (em.Law, em.Law.Splits.SEX, True),
+        (em.Sqf, em.Sqf.Splits.RACE_SEX, True),
     ],
 )
 def test_datasets_with_split(

--- a/tests/loading_data_test.py
+++ b/tests/loading_data_test.py
@@ -7,8 +7,7 @@ import pandas as pd
 import pytest
 
 import ethicml as em
-from ethicml import Admissions, Compas, Credit, Crime, DataTuple, German, LoadableDataset
-from ethicml.data.tabular_data.adult import Adult, AdultSplits
+from ethicml import Admissions, Adult, Compas, Credit, Crime, DataTuple, German, LoadableDataset
 from ethicml.data.util import flatten_dict
 
 
@@ -138,7 +137,7 @@ def idfn(val: DT):
             sum_y=11_208,
         ),
         DT(
-            dataset=em.adult(split=AdultSplits.SEX),
+            dataset=em.adult(split=Adult.Splits.SEX),
             samples=45_222,
             x_features=101,
             discrete_features=96,
@@ -164,7 +163,7 @@ def idfn(val: DT):
             sum_y=11_208,
         ),
         DT(
-            dataset=em.adult(split=AdultSplits.RACE),
+            dataset=em.adult(split=Adult.Splits.RACE),
             samples=45_222,
             x_features=98,
             discrete_features=93,


### PR DESCRIPTION
They are not real type aliases though and can't be used for type annotations.

This is a backport of  #587.