### PR TITLE
Don't let DataTuple inherit from TestTuple

### DIFF
--- a/ethicml/__init__.py
+++ b/ethicml/__init__.py
@@ -50,6 +50,7 @@ from .data.tabular_data.toy import *
 from .data.util import *
 from .evaluators.cross_validator import *
 from .evaluators.evaluate_models import *
+from .evaluators.parallelism import *
 from .metrics import *
 from .preprocessing.adjust_labels import *
 from .preprocessing.biased_split import *

--- a/ethicml/algorithms/inprocess/fair_dummies.py
+++ b/ethicml/algorithms/inprocess/fair_dummies.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List
-from typing_extensions import Final, Literal, TypedDict
+from typing_extensions import Literal, TypedDict
 
 from ranzen import implements
 

--- a/ethicml/algorithms/inprocess/fair_dummies.py
+++ b/ethicml/algorithms/inprocess/fair_dummies.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Final, Literal, TypedDict
 
 from ranzen import implements
 
@@ -52,7 +52,9 @@ class FairDummies(InAlgorithmSubprocess):
 
     @implements(InAlgorithmSubprocess)
     def _get_flags(self) -> FairDummiesArgs:
-        model_type = "deep_model" if self.model_type.lower() == "deep_model" else "linear_model"
+        model_type: Literal["deep_model", "linear_model"] = (
+            "deep_model" if self.model_type.lower() == "deep_model" else "linear_model"
+        )
         return {
             "lr": self.lr,
             "pretrain_pred_epochs": self.pretrain_pred_epochs,

--- a/ethicml/algorithms/inprocess/in_algorithm.py
+++ b/ethicml/algorithms/inprocess/in_algorithm.py
@@ -8,14 +8,7 @@ from typing import ClassVar, TypeVar
 from typing_extensions import final
 
 from ethicml.algorithms.algorithm_base import Algorithm
-from ethicml.utility import (
-    DataTuple,
-    FairnessType,
-    HyperParamType,
-    KernelType,
-    Prediction,
-    TestTuple,
-)
+from ethicml.utility import DataTuple, HyperParamType, Prediction, TestTuple
 
 __all__ = [
     "InAlgorithm",

--- a/ethicml/algorithms/inprocess/kamishima.py
+++ b/ethicml/algorithms/inprocess/kamishima.py
@@ -103,7 +103,7 @@ def _create_file_in_kamishima_format(data: Union[DataTuple, TestTuple], file_pat
     :param file_path: Path to the file.
     """
     if isinstance(data, DataTuple):
-        result = pd.concat([data.x, data.s, data.y], axis="columns").to_numpy().astype(np.float64)
+        result = data.data.to_numpy().astype(np.float64)
     else:
         zeros = pd.DataFrame([0 for _ in range(data.x.shape[0])], columns=["y"])
         result = pd.concat([data.x, data.s, zeros], axis="columns").to_numpy().astype(np.float64)

--- a/ethicml/algorithms/inprocess/kamishima.py
+++ b/ethicml/algorithms/inprocess/kamishima.py
@@ -103,7 +103,7 @@ def _create_file_in_kamishima_format(data: Union[DataTuple, TestTuple], file_pat
     :param file_path: Path to the file.
     """
     if isinstance(data, DataTuple):
-        result = data.data.to_numpy().astype(np.float64)
+        result = pd.concat([data.x, data.s, data.y], axis="columns").to_numpy().astype(np.float64)
     else:
         zeros = pd.DataFrame([0 for _ in range(data.x.shape[0])], columns=["y"])
         result = pd.concat([data.x, data.s, zeros], axis="columns").to_numpy().astype(np.float64)

--- a/ethicml/algorithms/preprocess/calders.py
+++ b/ethicml/algorithms/preprocess/calders.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Tuple
 import pandas as pd
 from ranzen import implements
 
-from ethicml.utility import DataTuple, SoftPrediction, TestTuple, concat
+from ethicml.utility import DataTuple, SoftPrediction, concat
 
 from ..inprocess.logistic_regression import LR
 from .pre_algorithm import PreAlgorithm, T
@@ -45,21 +45,19 @@ class Calders(PreAlgorithm):
         return data.replace(name=f"{self.name}: {data.name}")
 
     @implements(PreAlgorithm)
-    def run(
-        self, train: DataTuple, test: TestTuple, seed: int = 888
-    ) -> Tuple[DataTuple, TestTuple]:
+    def run(self, train: DataTuple, test: T, seed: int = 888) -> Tuple[DataTuple, T]:
         self._out_size = train.x.shape[1]
         new_train, new_test = _calders_algorithm(
             train, test, self.preferable_class, self.disadvantaged_group, seed
         )
-        return new_train.replace(name=f"{self.name}: {train.name}"), new_test.replace(
+        return new_train.rename(name=f"{self.name}: {train.name}"), new_test.rename(
             name=f"{self.name}: {test.name}"
         )
 
 
 def _calders_algorithm(
-    dataset: DataTuple, test: TestTuple, good_class: int, disadvantaged_group: int, seed: int
-) -> Tuple[DataTuple, TestTuple]:
+    dataset: DataTuple, test: T, good_class: int, disadvantaged_group: int, seed: int
+) -> Tuple[DataTuple, T]:
     s_vals: List[int] = list(map(int, dataset.s.unique()))
     y_vals: List[int] = list(map(int, dataset.y.unique()))
 

--- a/ethicml/algorithms/preprocess/calders.py
+++ b/ethicml/algorithms/preprocess/calders.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Tuple
 import pandas as pd
 from ranzen import implements
 
-from ethicml.utility import DataTuple, SoftPrediction, TestTuple, concat_dt
+from ethicml.utility import DataTuple, SoftPrediction, TestTuple, concat
 
 from ..inprocess.logistic_regression import LR
 from .pre_algorithm import PreAlgorithm, T
@@ -85,7 +85,7 @@ def _calders_algorithm(
     dis_group = (disadvantaged_group, bad_class)
     adv_group = (advantaged_group, good_class)
 
-    massaging_candidates = concat_dt([data[dis_group], data[adv_group]])
+    massaging_candidates = concat([data[dis_group], data[adv_group]])
 
     ranker = LR()
     rank: SoftPrediction = ranker.run(dataset, massaging_candidates, seed)
@@ -123,4 +123,4 @@ def _calders_algorithm(
     data[dis_group].y.iloc[:num_to_swap] = good_class  # type: ignore[call-overload]
     data[adv_group].y.iloc[:num_to_swap] = bad_class  # type: ignore[call-overload]
 
-    return concat_dt(list(data.values())), test
+    return concat(list(data.values())), test

--- a/ethicml/algorithms/preprocess/calders.py
+++ b/ethicml/algorithms/preprocess/calders.py
@@ -73,12 +73,7 @@ def _calders_algorithm(
     data: Dict[Tuple[int, int], DataTuple] = {}
     for s, y in groups:
         s_y_mask = (dataset.s == s) & (dataset.y == y)
-        data[(s, y)] = DataTuple.from_df(
-            x=dataset.x.loc[s_y_mask].reset_index(drop=True),
-            s=dataset.s.loc[s_y_mask].reset_index(drop=True),
-            y=dataset.y.loc[s_y_mask].reset_index(drop=True),
-            name=dataset.name,
-        )
+        data[(s, y)] = dataset.replace_data(data=dataset.data.loc[s_y_mask].reset_index(drop=True))
 
     dis_group = (disadvantaged_group, bad_class)
     adv_group = (advantaged_group, good_class)
@@ -102,11 +97,8 @@ def _calders_algorithm(
     # use the rank to sort the data
     for group, ranking in [(dis_group, dis_group_rank), (adv_group, adv_group_rank)]:
         unsorted_data = data[group]
-        data[group] = DataTuple.from_df(
-            x=unsorted_data.x.reindex(index=ranking.index).reset_index(drop=True),
-            s=unsorted_data.s.reindex(index=ranking.index).reset_index(drop=True),
-            y=unsorted_data.y.reindex(index=ranking.index).reset_index(drop=True),
-            name=unsorted_data.name,
+        data[group] = unsorted_data.replace_data(
+            data=unsorted_data.data.reindex(index=ranking.index).reset_index(drop=True)
         )
 
     all_disadvantaged = len(data[(disadvantaged_group, good_class)]) + dis_group_len

--- a/ethicml/algorithms/preprocess/calders.py
+++ b/ethicml/algorithms/preprocess/calders.py
@@ -38,11 +38,11 @@ class Calders(PreAlgorithm):
         new_train, _ = _calders_algorithm(
             train, train, self.preferable_class, self.disadvantaged_group, seed
         )
-        return self, new_train.replace(name=f"{self.name}: {train.name}")
+        return self, new_train.rename(f"{self.name}: {train.name}")
 
     @implements(PreAlgorithm)
     def transform(self, data: T) -> T:
-        return data.replace(name=f"{self.name}: {data.name}")
+        return data.rename(f"{self.name}: {data.name}")
 
     @implements(PreAlgorithm)
     def run(self, train: DataTuple, test: T, seed: int = 888) -> Tuple[DataTuple, T]:

--- a/ethicml/algorithms/preprocess/pre_algorithm.py
+++ b/ethicml/algorithms/preprocess/pre_algorithm.py
@@ -5,11 +5,11 @@ from abc import ABC, abstractmethod
 from typing import Tuple, TypeVar
 
 from ethicml.algorithms.algorithm_base import Algorithm
-from ethicml.utility import DataTuple, TestTuple
+from ethicml.utility import DataTuple, SubgroupTuple
 
 __all__ = ["PreAlgorithm"]
 
-T = TypeVar("T", DataTuple, TestTuple)
+T = TypeVar("T", DataTuple, SubgroupTuple)
 _PA = TypeVar("_PA", bound="PreAlgorithm")
 
 
@@ -34,9 +34,7 @@ class PreAlgorithm(Algorithm, ABC):
         """
 
     @abstractmethod
-    def run(
-        self, train: DataTuple, test: TestTuple, seed: int = 888
-    ) -> Tuple[DataTuple, TestTuple]:
+    def run(self, train: DataTuple, test: T, seed: int = 888) -> Tuple[DataTuple, T]:
         """Generate fair features with the given data.
 
         :param train: Data tuple of the training data.
@@ -45,9 +43,7 @@ class PreAlgorithm(Algorithm, ABC):
         :returns: A tuple of the transforme training data and the test data.
         """
 
-    def run_test(
-        self, train: DataTuple, test: TestTuple, seed: int = 888
-    ) -> Tuple[DataTuple, TestTuple]:
+    def run_test(self, train: DataTuple, test: T, seed: int = 888) -> Tuple[DataTuple, T]:
         """Run with reduced training set so that it finishes quicker.
 
         :param train: Data tuple of the training data.

--- a/ethicml/algorithms/preprocess/pre_subprocess.py
+++ b/ethicml/algorithms/preprocess/pre_subprocess.py
@@ -9,11 +9,11 @@ from typing_extensions import Literal, TypeAlias, TypedDict, final
 
 from ethicml.algorithms.algorithm_base import SubprocessAlgorithmMixin
 from ethicml.algorithms.preprocess.pre_algorithm import PreAlgorithm
-from ethicml.utility import DataTuple, TestTuple
+from ethicml.utility import DataTuple, SubgroupTuple
 
 __all__ = ["PreAlgoArgs", "PreAlgorithmSubprocess"]
 
-T = TypeVar("T", DataTuple, TestTuple)
+T = TypeVar("T", DataTuple, SubgroupTuple)
 
 
 class PreAlgoRunArgs(TypedDict):
@@ -139,9 +139,7 @@ class PreAlgorithmSubprocess(SubprocessAlgorithmMixin, PreAlgorithm, ABC):
         return transformed_test
 
     @final
-    def run(
-        self, train: DataTuple, test: TestTuple, seed: int = 888
-    ) -> Tuple[DataTuple, TestTuple]:
+    def run(self, train: DataTuple, test: T, seed: int = 888) -> Tuple[DataTuple, T]:
         """Generate fair features in a subprocess with the given data.
 
         :param train: Data tuple of the training data.
@@ -174,7 +172,7 @@ class PreAlgorithmSubprocess(SubprocessAlgorithmMixin, PreAlgorithm, ABC):
 
             # ================================== load results =====================================
             transformed_train = DataTuple.from_npz(transformed_train_path)
-            transformed_test = TestTuple.from_npz(transformed_test_path)
+            transformed_test = test.from_npz(transformed_test_path)
 
         # prefix the name of the algorithm to the dataset name
         transformed_train = transformed_train.replace(

--- a/ethicml/algorithms/preprocess/pre_subprocess.py
+++ b/ethicml/algorithms/preprocess/pre_subprocess.py
@@ -99,9 +99,8 @@ class PreAlgorithmSubprocess(SubprocessAlgorithmMixin, PreAlgorithm, ABC):
             transformed_train = DataTuple.from_npz(transformed_train_path)
 
         # prefix the name of the algorithm to the dataset name
-        transformed_train = transformed_train.replace(
-            name=None if train.name is None else f"{self.name}: {train.name}"
-        )
+        if train.name is not None:
+            transformed_train = transformed_train.rename(f"{self.name}: {train.name}")
         return self, transformed_train
 
     @final
@@ -133,9 +132,8 @@ class PreAlgorithmSubprocess(SubprocessAlgorithmMixin, PreAlgorithm, ABC):
             transformed_test: T = data.from_npz(transformed_test_path)
 
         # prefix the name of the algorithm to the dataset name
-        transformed_test = transformed_test.replace(
-            name=None if data.name is None else f"{self.name}: {data.name}"
-        )
+        if data.name is not None:
+            transformed_test = transformed_test.rename(f"{self.name}: {data.name}")
         return transformed_test
 
     @final
@@ -175,12 +173,10 @@ class PreAlgorithmSubprocess(SubprocessAlgorithmMixin, PreAlgorithm, ABC):
             transformed_test = test.from_npz(transformed_test_path)
 
         # prefix the name of the algorithm to the dataset name
-        transformed_train = transformed_train.replace(
-            name=None if train.name is None else f"{self.name}: {train.name}"
-        )
-        transformed_test = transformed_test.replace(
-            name=None if test.name is None else f"{self.name}: {test.name}"
-        )
+        if train.name is not None:
+            transformed_train = transformed_train.rename(f"{self.name}: {train.name}")
+        if test.name is not None:
+            transformed_test = transformed_test.rename(f"{self.name}: {test.name}")
         return transformed_train, transformed_test
 
     @final

--- a/ethicml/algorithms/preprocess/upsampler.py
+++ b/ethicml/algorithms/preprocess/upsampler.py
@@ -54,7 +54,7 @@ class Upsampler(PreAlgorithm):
 
     @implements(PreAlgorithm)
     def transform(self, data: T) -> T:
-        return data.replace(name=f"{self.name}: {data.name}")
+        return data.rename(f"{self.name}: {data.name}")
 
     @implements(PreAlgorithm)
     def run(self, train: DataTuple, test: T, seed: int = 888) -> Tuple[DataTuple, T]:
@@ -140,7 +140,7 @@ def upsample(
             upsampled_datatuple = val
         else:
             upsampled_datatuple = concat_datatuples(upsampled_datatuple, val)
-            upsampled_datatuple = upsampled_datatuple.replace(name=f"{name}: {dataset.name}")
+            upsampled_datatuple = upsampled_datatuple.rename(f"{name}: {dataset.name}")
 
     if strategy is UpsampleStrategy.preferential:
         ranker = LR()

--- a/ethicml/data/dataset.py
+++ b/ethicml/data/dataset.py
@@ -343,13 +343,13 @@ class LoadableDataset(Dataset):
         if self.disc_feature_groups is not None:
             data_collapsed = self._from_dummies(data.x, self.disc_feature_groups)
             data = data.replace(x=data_collapsed)
-        df = pd.concat([data.x, data.s, data.y], axis="columns")
+        df = data.data
 
         return StandardDataset(
             df=df,
-            label_name=data.y.name,
+            label_name=data.y_column,
             favorable_classes=lambda x: x > 0,
-            protected_attribute_names=[data.s.name],
+            protected_attribute_names=[data.s_column],
             privileged_classes=[lambda x: x == 1],
             categorical_features=self.disc_feature_groups.keys()
             if self.disc_feature_groups is not None

--- a/ethicml/evaluators/cross_validator.py
+++ b/ethicml/evaluators/cross_validator.py
@@ -10,7 +10,7 @@ from ethicml.metrics.accuracy import Accuracy
 from ethicml.metrics.cv import AbsCV
 from ethicml.metrics.metric import Metric
 from ethicml.preprocessing.splits import fold_data
-from ethicml.utility import DataTuple, Prediction, TrainTestPair
+from ethicml.utility import DataTuple, Prediction, TrainValPair
 
 __all__ = ["CrossValidator", "CVResults"]
 
@@ -222,7 +222,7 @@ class CrossValidator:
         # create all folds
         data_folds: List[Tuple[DataTuple, DataTuple]] = list(fold_data(train, folds=self.folds))
         # convert to right format
-        pair_folds = [TrainTestPair(train_fold, val) for (train_fold, val) in data_folds]
+        pair_folds = [TrainValPair(train_fold, val) for (train_fold, val) in data_folds]
         # run everything in parallel
         all_results = run_in_parallel(
             algos=models,

--- a/ethicml/evaluators/evaluate_models.py
+++ b/ethicml/evaluators/evaluate_models.py
@@ -26,7 +26,7 @@ from ethicml.utility.data_structures import (
     Prediction,
     Results,
     ResultsAggregator,
-    TrainTestPair,
+    TrainValPair,
     make_results,
 )
 
@@ -198,7 +198,7 @@ def evaluate_models(
     all_results = ResultsAggregator()
 
     # ======================================= prepare data ========================================
-    data_splits: List[TrainTestPair] = []
+    data_splits: List[TrainValPair] = []
     test_data: List[_DataInfo] = []  # contains the test set and other things needed for the metrics
     model_seeds: List[int] = []
     for dataset in datasets:
@@ -213,7 +213,7 @@ def evaluate_models(
                 # take smaller subset of training data to speed up training
                 train = train.get_n_samples()
             train = train.replace(name=f"{train.name} ({split_id})")
-            data_splits.append(TrainTestPair(train, test))
+            data_splits.append(TrainValPair(train, test))
             model_seeds.append(0 if repeat_on == "data" else split_id)
             split_info.update({"split_id": split_id})
             test_data.append(
@@ -246,11 +246,11 @@ def evaluate_models(
     )
 
     # append the transformed data to `transformed_data`
-    transformed_data: List[TrainTestPair] = []
+    transformed_data: List[TrainValPair] = []
     transformed_test: List[_DataInfo] = []
     for transformed, pre_model in zip(all_transformed, preprocess_models):
         for (transf_train, transf_test), data_info in zip(transformed, test_data):
-            transformed_data.append(TrainTestPair(transf_train, transf_test))
+            transformed_data.append(TrainValPair(transf_train, transf_test))
             transformed_test.append(
                 _DataInfo(
                     test=data_info.test,

--- a/ethicml/evaluators/evaluate_models.py
+++ b/ethicml/evaluators/evaluate_models.py
@@ -212,7 +212,7 @@ def evaluate_models(
             if test_mode:
                 # take smaller subset of training data to speed up training
                 train = train.get_n_samples()
-            train = train.replace(name=f"{train.name} ({split_id})")
+            train = train.rename(f"{train.name} ({split_id})")
             data_splits.append(TrainValPair(train, test))
             model_seeds.append(0 if repeat_on == "data" else split_id)
             split_info.update({"split_id": split_id})

--- a/ethicml/evaluators/evaluate_models.py
+++ b/ethicml/evaluators/evaluate_models.py
@@ -21,7 +21,7 @@ from ethicml.preprocessing.scaling import ScalerType, scale_continuous
 from ethicml.preprocessing.splits import DataSplitter, RandomSplit
 from ethicml.utility.data_structures import (
     DataTuple,
-    HyperParamType,
+    EvalTuple,
     HyperParamValue,
     Prediction,
     Results,
@@ -58,7 +58,7 @@ def per_sens_metrics_check(per_sens_metrics: Sequence[Metric]) -> None:
 
 def run_metrics(
     predictions: Prediction,
-    actual: DataTuple,
+    actual: EvalTuple,
     metrics: Sequence[Metric] = (),
     per_sens_metrics: Sequence[Metric] = (),
     diffs_and_ratios: bool = True,
@@ -67,7 +67,7 @@ def run_metrics(
     """Run all the given metrics on the given predictions and return the results.
 
     :param predictions: DataFrame with predictions
-    :param actual: DataTuple with the labels
+    :param actual: EvalTuple with the labels
     :param metrics: list of metrics (Default: ())
     :param per_sens_metrics: list of metrics that are computed per sensitive attribute (Default: ())
     :param diffs_and_ratios: if True, compute diffs and ratios per sensitive attribute (Default: True)

--- a/ethicml/implementations/agarwal.py
+++ b/ethicml/implementations/agarwal.py
@@ -22,6 +22,7 @@ from ethicml.utility import (
     FairnessType,
     KernelType,
     Prediction,
+    SubgroupTuple,
     TestTuple,
 )
 
@@ -143,7 +144,7 @@ def main() -> None:
     if in_algo_args["mode"] == "run":
         random.seed(in_algo_args["seed"])
         np.random.seed(in_algo_args["seed"])
-        train, test = DataTuple.from_npz(Path(in_algo_args["train"])), TestTuple.from_npz(
+        train, test = DataTuple.from_npz(Path(in_algo_args["train"])), SubgroupTuple.from_npz(
             Path(in_algo_args["test"])
         )
         Prediction(
@@ -159,7 +160,7 @@ def main() -> None:
             model_file = cloudpickle.dumps(model)
         dump(model_file, Path(in_algo_args["model"]))
     elif in_algo_args["mode"] == "predict":
-        testdata = TestTuple.from_npz(Path(in_algo_args["test"]))
+        testdata = SubgroupTuple.from_npz(Path(in_algo_args["test"]))
         model_file = load(Path(in_algo_args["model"]))
         with working_dir(Path(in_algo_args["model"])):
             model = cloudpickle.loads(model_file)

--- a/ethicml/implementations/beutel.py
+++ b/ethicml/implementations/beutel.py
@@ -21,7 +21,7 @@ from torch.optim.lr_scheduler import ExponentialLR
 
 from ethicml.preprocessing.adjust_labels import LabelBinarizer, assert_binary_labels
 from ethicml.preprocessing.splits import train_test_split
-from ethicml.utility import DataTuple, FairnessType, TestTuple
+from ethicml.utility import DataTuple, FairnessType
 
 from .pytorch_common import CustomDataset, TestDataset, make_dataset_and_loader
 from .utils import load_data_from_flags, save_transformations
@@ -208,8 +208,8 @@ def transform(data: T, enc: torch.nn.Module, flags: BeutelArgs) -> T:
 
 
 def train_and_transform(
-    train: DataTuple, test: TestTuple, flags: BeutelArgs, seed: int
-) -> Tuple[DataTuple, TestTuple]:
+    train: DataTuple, test: T, flags: BeutelArgs, seed: int
+) -> Tuple[DataTuple, T]:
     """Train the fair autoencoder on the training data and then transform both training and test.
 
     :param train:
@@ -274,9 +274,7 @@ def encode_dataset(
     )
 
 
-def encode_testset(
-    enc: nn.Module, dataloader: torch.utils.data.DataLoader, testtuple: TestTuple
-) -> TestTuple:
+def encode_testset(enc: nn.Module, dataloader: torch.utils.data.DataLoader, testtuple: T) -> T:
     """Encode a dataset.
 
     :param enc:
@@ -289,7 +287,7 @@ def encode_testset(
     for embedding, _ in dataloader:
         data_to_return += enc(embedding).data.numpy().tolist()
 
-    return TestTuple.from_df(x=pd.DataFrame(data_to_return), s=testtuple.s, name=testtuple.name)
+    return testtuple.replace(x=pd.DataFrame(data_to_return))
 
 
 class GradReverse(Function):
@@ -468,9 +466,8 @@ def main() -> None:
         transformed_train.to_npz(Path(pre_algo_args["new_train"]))
         dump(enc, Path(pre_algo_args["model"]))
     elif pre_algo_args["mode"] == "transform":
-        test = DataTuple.from_npz(Path(pre_algo_args["test"]))
         model = load(Path(pre_algo_args["model"]))
-        transformed_test = transform(test, model, flags)
+        transformed_test = transform(DataTuple.from_npz(Path(pre_algo_args["test"])), model, flags)
         transformed_test.to_npz(Path(pre_algo_args["new_test"]))
 
 

--- a/ethicml/implementations/beutel.py
+++ b/ethicml/implementations/beutel.py
@@ -198,13 +198,7 @@ def transform(data: T, enc: torch.nn.Module, flags: BeutelArgs) -> T:
     test_loader = torch.utils.data.DataLoader(
         dataset=test_data, batch_size=flags["batch_size"], shuffle=False
     )
-    test_transformed = encode_testset(enc, test_loader, data)
-    if isinstance(data, DataTuple):
-        return DataTuple.from_df(
-            x=test_transformed.x, s=data.s, y=data.y, name=test_transformed.name
-        )
-    else:
-        return test_transformed
+    return encode_testset(enc, test_loader, data)
 
 
 def train_and_transform(
@@ -266,12 +260,7 @@ def encode_dataset(
     for embedding, _, _ in dataloader:
         data_to_return += enc(embedding).data.numpy().tolist()
 
-    return DataTuple.from_df(
-        x=pd.DataFrame(data_to_return),
-        s=datatuple.s,
-        y=datatuple.y,
-        name=f"Beutel: {datatuple.name}",
-    )
+    return datatuple.replace(x=pd.DataFrame(data_to_return), name=f"Beutel: {datatuple.name}")
 
 
 def encode_testset(enc: nn.Module, dataloader: torch.utils.data.DataLoader, testtuple: T) -> T:

--- a/ethicml/implementations/beutel.py
+++ b/ethicml/implementations/beutel.py
@@ -260,7 +260,7 @@ def encode_dataset(
     for embedding, _, _ in dataloader:
         data_to_return += enc(embedding).data.numpy().tolist()
 
-    return datatuple.replace(x=pd.DataFrame(data_to_return), name=f"Beutel: {datatuple.name}")
+    return datatuple.replace(x=pd.DataFrame(data_to_return)).rename(f"Beutel: {datatuple.name}")
 
 
 def encode_testset(enc: nn.Module, dataloader: torch.utils.data.DataLoader, testtuple: T) -> T:

--- a/ethicml/implementations/dro_tabular.py
+++ b/ethicml/implementations/dro_tabular.py
@@ -27,7 +27,7 @@ from ethicml.implementations.beutel import set_seed
 from ethicml.implementations.dro_modules.dro_classifier import DROClassifier
 from ethicml.implementations.pytorch_common import CustomDataset, TestDataset
 from ethicml.implementations.utils import load_data_from_flags
-from ethicml.utility import DataTuple, SoftPrediction, TestTuple
+from ethicml.utility import DataTuple, SoftPrediction, SubgroupTuple, TestTuple
 
 if TYPE_CHECKING:
     from ethicml.algorithms.inprocess.fairness_wo_demographics import DroArgs
@@ -167,7 +167,7 @@ def main() -> None:
         model = fit(data, flags, seed=in_algo_args["seed"])
         dump(model, Path(in_algo_args["model"]))
     elif in_algo_args["mode"] == "predict":
-        data = TestTuple.from_npz(Path(in_algo_args["test"]))
+        data = SubgroupTuple.from_npz(Path(in_algo_args["test"]))
         model = load(Path(in_algo_args["model"]))
         predict(model, data, flags).to_npz(Path(in_algo_args["predictions"]))
 

--- a/ethicml/implementations/fair_dummies_romano.py
+++ b/ethicml/implementations/fair_dummies_romano.py
@@ -11,8 +11,8 @@ import numpy as np
 import torch
 from joblib import dump, load
 
-from ethicml import DataTuple, SoftPrediction, TestTuple
 from ethicml.implementations.fair_dummies_modules.model import EquiClassLearner
+from ethicml.utility import DataTuple, SoftPrediction, SubgroupTuple, TestTuple
 
 if TYPE_CHECKING:
     from ethicml.algorithms.inprocess.fair_dummies import FairDummiesArgs
@@ -77,7 +77,7 @@ def main() -> None:
     flags: FairDummiesArgs = json.loads(sys.argv[2])
 
     if in_algo_args["mode"] == "run":
-        train, test = DataTuple.from_npz(Path(in_algo_args["train"])), TestTuple.from_npz(
+        train, test = DataTuple.from_npz(Path(in_algo_args["train"])), SubgroupTuple.from_npz(
             Path(in_algo_args["test"])
         )
         SoftPrediction(soft=train_and_predict(train, test, flags, in_algo_args["seed"])).to_npz(
@@ -89,7 +89,7 @@ def main() -> None:
         setattr(model, "ethicml_random_seed", in_algo_args["seed"])  # need to save the seed as well
         dump(model, Path(in_algo_args["model"]))
     elif in_algo_args["mode"] == "predict":
-        test = TestTuple.from_npz(Path(in_algo_args["test"]))
+        test = SubgroupTuple.from_npz(Path(in_algo_args["test"]))
         model = load(Path(in_algo_args["model"]))
         SoftPrediction(soft=predict(model, test)).to_npz(Path(in_algo_args["predictions"]))
     else:

--- a/ethicml/implementations/hgr_method.py
+++ b/ethicml/implementations/hgr_method.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from joblib import dump, load
 
-from ethicml import DataTuple, SoftPrediction, TestTuple
+from ethicml import DataTuple, SoftPrediction, SubgroupTuple
 from ethicml.implementations.hgr_modules.hgr_impl import HgrClassLearner
 
 if TYPE_CHECKING:
@@ -49,7 +49,7 @@ def fit(train: DataTuple, args: HgrArgs, seed: int = 888) -> HgrClassLearner:
     return model.fit(train, seed=seed)
 
 
-def predict(model: HgrClassLearner, test: TestTuple) -> np.ndarray:
+def predict(model: HgrClassLearner, test: SubgroupTuple) -> np.ndarray:
     """Compute predictions on the given test data.
 
     :param exponentiated_gradient:
@@ -58,7 +58,9 @@ def predict(model: HgrClassLearner, test: TestTuple) -> np.ndarray:
     return model.predict(test.x)
 
 
-def train_and_predict(train: DataTuple, test: TestTuple, args: HgrArgs, seed: int) -> np.ndarray:
+def train_and_predict(
+    train: DataTuple, test: SubgroupTuple, args: HgrArgs, seed: int
+) -> np.ndarray:
     """Train a logistic regression model and compute predictions on the given test data.
 
     :param train:
@@ -75,7 +77,7 @@ def main() -> None:
     flags: HgrArgs = json.loads(sys.argv[2])
 
     if in_algo_args["mode"] == "run":
-        train, test = DataTuple.from_npz(Path(in_algo_args["train"])), TestTuple.from_npz(
+        train, test = DataTuple.from_npz(Path(in_algo_args["train"])), SubgroupTuple.from_npz(
             Path(in_algo_args["test"])
         )
         SoftPrediction(soft=train_and_predict(train, test, flags, in_algo_args["seed"])).to_npz(
@@ -87,7 +89,7 @@ def main() -> None:
         setattr(model, "ethicml_random_seed", in_algo_args["seed"])  # need to save the seed as well
         dump(model, Path(in_algo_args["model"]))
     elif in_algo_args["mode"] == "predict":
-        test = TestTuple.from_npz(Path(in_algo_args["test"]))
+        test = SubgroupTuple.from_npz(Path(in_algo_args["test"]))
         model = load(Path(in_algo_args["model"]))
         SoftPrediction(soft=predict(model, test)).to_npz(Path(in_algo_args["predictions"]))
     else:

--- a/ethicml/implementations/pytorch_common.py
+++ b/ethicml/implementations/pytorch_common.py
@@ -6,6 +6,8 @@ from typing_extensions import Literal
 import numpy as np
 import pandas as pd
 
+from ethicml.utility import DataTuple, TestTuple
+
 try:
     import torch
     from torch import Tensor, nn
@@ -14,9 +16,6 @@ except ImportError as e:
     raise RuntimeError(
         "In order to use PyTorch, please install it following the instructions as https://pytorch.org/ . "
     ) from e
-
-
-from ethicml.utility import DataTuple, TestTuple
 
 
 def _get_info(data: TestTuple) -> Tuple[np.ndarray, np.ndarray, int, int, pd.Index, str]:

--- a/ethicml/implementations/utils.py
+++ b/ethicml/implementations/utils.py
@@ -4,19 +4,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Tuple
 
-from ethicml.utility import DataTuple, TestTuple
+from ethicml.utility import DataTuple, SubgroupTuple, TestTuple
 
 if TYPE_CHECKING:
     from ethicml.algorithms.inprocess.in_subprocess import InAlgoRunArgs
     from ethicml.algorithms.preprocess.pre_subprocess import PreAlgoRunArgs
 
 
-def load_data_from_flags(args: PreAlgoRunArgs | InAlgoRunArgs) -> Tuple[DataTuple, TestTuple]:
+def load_data_from_flags(args: PreAlgoRunArgs | InAlgoRunArgs) -> Tuple[DataTuple, SubgroupTuple]:
     """Load data from the paths specified in the flags.
 
     :param args:
     """
-    return DataTuple.from_npz(Path(args["train"])), TestTuple.from_npz(Path(args["test"]))
+    return DataTuple.from_npz(Path(args["train"])), SubgroupTuple.from_npz(Path(args["test"]))
 
 
 def save_transformations(
@@ -29,6 +29,6 @@ def save_transformations(
     """
     train, test = transforms
     assert isinstance(train, DataTuple)
-    assert isinstance(test, TestTuple)
+    assert isinstance(test, (DataTuple, SubgroupTuple))
     train.to_npz(Path(pre_algo_run_args["new_train"]))
     test.to_npz(Path(pre_algo_run_args["new_test"]))

--- a/ethicml/implementations/vfae.py
+++ b/ethicml/implementations/vfae.py
@@ -83,7 +83,7 @@ def transform(model: VFAENetwork, dataset: T, flags: VfaeArgs) -> T:
             # z1 = model.reparameterize(z1_mu, z1_logvar)
             post_train += z1_mu.data.tolist()
 
-    return dataset.replace(x=pd.DataFrame(post_train), name=f"VFAE: {dataset.name}")
+    return dataset.replace(x=pd.DataFrame(post_train)).rename(f"VFAE: {dataset.name}")
 
 
 def train_and_transform(train: DataTuple, test: T, flags: VfaeArgs) -> Tuple[DataTuple, T]:

--- a/ethicml/implementations/vfae.py
+++ b/ethicml/implementations/vfae.py
@@ -15,7 +15,7 @@ from torch.utils.data import DataLoader
 
 from ethicml.data.lookup import get_dataset_obj_by_name
 from ethicml.implementations.beutel import set_seed
-from ethicml.utility import DataTuple, TestTuple
+from ethicml.utility import DataTuple, SubgroupTuple
 
 from .pytorch_common import CustomDataset, TestDataset
 from .utils import load_data_from_flags, save_transformations
@@ -67,7 +67,7 @@ def transform(model: VFAENetwork, dataset: T, flags: VfaeArgs) -> T:
     if isinstance(dataset, DataTuple):
         data = CustomDataset(dataset)
         loader = DataLoader(data, batch_size=flags["batch_size"], shuffle=False)
-    elif isinstance(dataset, TestTuple):
+    elif isinstance(dataset, SubgroupTuple):
         data = TestDataset(dataset)
         loader = DataLoader(data, batch_size=flags["batch_size"], shuffle=False)
 
@@ -77,25 +77,16 @@ def transform(model: VFAENetwork, dataset: T, flags: VfaeArgs) -> T:
         for sample in loader:
             if isinstance(dataset, DataTuple):
                 _x, _s, _ = sample
-            elif isinstance(dataset, TestTuple):
+            elif isinstance(dataset, SubgroupTuple):
                 _x, _s = sample
             z1_mu, z1_logvar = model.encode_z1(_x, _s)
             # z1 = model.reparameterize(z1_mu, z1_logvar)
             post_train += z1_mu.data.tolist()
 
-    if isinstance(dataset, DataTuple):
-        return DataTuple.from_df(
-            x=pd.DataFrame(post_train), s=dataset.s, y=dataset.y, name=f"VFAE: {dataset.name}"
-        )
-    elif isinstance(dataset, TestTuple):
-        return TestTuple.from_df(
-            x=pd.DataFrame(post_train), s=dataset.s, name=f"VFAE: {dataset.name}"
-        )
+    return dataset.replace(x=pd.DataFrame(post_train), name=f"VFAE: {dataset.name}")
 
 
-def train_and_transform(
-    train: DataTuple, test: TestTuple, flags: VfaeArgs
-) -> Tuple[DataTuple, TestTuple]:
+def train_and_transform(train: DataTuple, test: T, flags: VfaeArgs) -> Tuple[DataTuple, T]:
     """Train the model and transform the dataset.
 
     :param train:
@@ -177,9 +168,8 @@ def main() -> None:
         transformed_train.to_npz(Path(pre_algo_args["new_train"]))
         dump(enc, Path(pre_algo_args["model"]))
     elif pre_algo_args["mode"] == "transform":
-        test = DataTuple.from_npz(Path(pre_algo_args["test"]))
         model = load(Path(pre_algo_args["model"]))
-        transformed_test = transform(model, test, flags)
+        transformed_test = transform(model, DataTuple.from_npz(Path(pre_algo_args["test"])), flags)
         transformed_test.to_npz(Path(pre_algo_args["new_test"]))
 
 

--- a/ethicml/metrics/accuracy.py
+++ b/ethicml/metrics/accuracy.py
@@ -7,7 +7,7 @@ import pandas as pd
 from ranzen import implements
 from sklearn.metrics import accuracy_score, f1_score
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .metric import MetricStaticName
 
@@ -21,7 +21,7 @@ class SklearnMetric(MetricStaticName, ABC):
     sklearn_metric: ClassVar[Tuple[Callable[[pd.Series, pd.Series], float]]]
 
     @implements(MetricStaticName)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         return self.sklearn_metric[0](actual.y, prediction.hard)
 
 
@@ -50,7 +50,7 @@ class RobustAccuracy(SklearnMetric):
     _name: ClassVar[str] = "Robust Accuracy"
 
     @implements(SklearnMetric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         score_func = super().score
         return min(
             [

--- a/ethicml/metrics/anti_spur.py
+++ b/ethicml/metrics/anti_spur.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .metric import Metric, MetricStaticName
 
@@ -21,7 +21,7 @@ class AS(MetricStaticName):
     _name: ClassVar[str] = "anti_spurious"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         preds = prediction.hard.to_numpy()
         sens = actual.s.to_numpy()
         labels = actual.y.to_numpy()

--- a/ethicml/metrics/average_odds.py
+++ b/ethicml/metrics/average_odds.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .fpr import FPR
@@ -28,7 +28,7 @@ class AverageOddsDiff(CfmMetric):
     apply_per_sensitive: ClassVar[bool] = False
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         tpr = TPR(pos_class=self.pos_class, labels=self.labels)
         tpr_per_sens = metric_per_sensitive_attribute(prediction, actual, tpr)
         fpr = FPR(pos_class=self.pos_class, labels=self.labels)

--- a/ethicml/metrics/balanced_accuracy.py
+++ b/ethicml/metrics/balanced_accuracy.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -19,7 +19,7 @@ class BalancedAccuracy(CfmMetric):
     _name: ClassVar[str] = "Balanced Accuracy"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         t_neg, f_pos, f_neg, t_pos = self.confusion_matrix(prediction=prediction, actual=actual)
         tpr = t_pos / (t_pos + f_neg)
         tnr = t_neg / (t_neg + f_pos)

--- a/ethicml/metrics/bcr.py
+++ b/ethicml/metrics/bcr.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -21,7 +21,7 @@ class BCR(CfmMetric):
     _name: ClassVar[str] = "BCR"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         tpr = TPR(pos_class=self.pos_class, labels=self.labels).score(prediction, actual)
         tnr = TNR(pos_class=self.pos_class, labels=self.labels).score(prediction, actual)
 

--- a/ethicml/metrics/confusion_matrix.py
+++ b/ethicml/metrics/confusion_matrix.py
@@ -7,7 +7,7 @@ import numpy as np
 from sklearn.metrics import confusion_matrix as conf_mtx
 
 from ethicml.metrics.metric import MetricStaticName
-from ethicml.utility.data_structures import DataTuple, Prediction
+from ethicml.utility.data_structures import EvalTuple, Prediction
 
 __all__ = ["CfmMetric", "LabelOutOfBounds"]
 
@@ -22,7 +22,7 @@ class CfmMetric(MetricStaticName):
     """List of possible target values. If `None`, then this is inferred from the data when run."""
 
     def confusion_matrix(
-        self, prediction: Prediction, actual: DataTuple
+        self, prediction: Prediction, actual: EvalTuple
     ) -> Tuple[int, int, int, int]:
         """Apply sci-kit learn's confusion matrix.
 

--- a/ethicml/metrics/cv.py
+++ b/ethicml/metrics/cv.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import MetricStaticName
@@ -22,7 +22,7 @@ class CV(CfmMetric):
     apply_per_sensitive: ClassVar[bool] = False
 
     @implements(MetricStaticName)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         prob_pos = ProbPos(pos_class=self.pos_class, labels=self.labels)
         per_sens = metric_per_sensitive_attribute(prediction, actual, metric=prob_pos)
         diffs = diff_per_sensitive_attribute(per_sens)
@@ -40,7 +40,7 @@ class AbsCV(CV):
     _name: ClassVar[str] = "CV absolute"
 
     @implements(MetricStaticName)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         cv_score = super().score(prediction, actual)
         # the following is equivalent to 1 - abs(diff)
         if cv_score > 1:

--- a/ethicml/metrics/dependence_measures.py
+++ b/ethicml/metrics/dependence_measures.py
@@ -8,7 +8,7 @@ import numpy as np
 from ranzen import enum_name_str, implements
 from sklearn.metrics import normalized_mutual_info_score
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .metric import Metric
 
@@ -46,7 +46,7 @@ class NMI(_DependenceMeasure):
     _base_name: ClassVar[str] = "NMI"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         base_values = actual.y if self.base is DependencyTarget.y else actual.s
         return normalized_mutual_info_score(
             base_values.to_numpy().ravel(),
@@ -66,7 +66,7 @@ class Yanovich(_DependenceMeasure):
     _base_name: ClassVar[str] = "Yanovich"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         base_values = actual.y if self.base is DependencyTarget.y else actual.s
         return self._dependence(base_values.to_numpy().ravel(), prediction.hard.to_numpy().ravel())
 
@@ -121,7 +121,7 @@ class RenyiCorrelation(_DependenceMeasure):
     _base_name: ClassVar[str] = "Renyi"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         base_values = actual.y if self.base is DependencyTarget.y else actual.s
         return self._corr(base_values.to_numpy().ravel(), prediction.hard.to_numpy().ravel())
 

--- a/ethicml/metrics/fnr.py
+++ b/ethicml/metrics/fnr.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -19,6 +19,6 @@ class FNR(CfmMetric):
     _name: ClassVar[str] = "FNR"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         _, _, f_neg, t_pos = self.confusion_matrix(prediction=prediction, actual=actual)
         return f_neg / (f_neg + t_pos)

--- a/ethicml/metrics/fpr.py
+++ b/ethicml/metrics/fpr.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -19,6 +19,6 @@ class FPR(CfmMetric):
     _name: ClassVar[str] = "FPR"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         t_neg, f_pos, _, _ = self.confusion_matrix(prediction=prediction, actual=actual)
         return f_pos / (f_pos + t_neg)

--- a/ethicml/metrics/hsic.py
+++ b/ethicml/metrics/hsic.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.random import RandomState
 
 from ethicml.metrics.metric import MetricStaticName
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 __all__ = ["Hsic"]
 
@@ -66,7 +66,7 @@ class Hsic(MetricStaticName):
     _name: ClassVar[str] = "HSIC"
     apply_per_sensitive: ClassVar[bool] = False
 
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         """We add the ability to take the average of hsic score.
 
         As for larger datasets it will kill your machine

--- a/ethicml/metrics/metric.py
+++ b/ethicml/metrics/metric.py
@@ -6,7 +6,7 @@ from typing_extensions import final
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 __all__ = ["MetricStaticName", "Metric"]
 
@@ -18,11 +18,11 @@ class Metric(ABC):
     """Whether the metric can be applied per sensitive attribute."""
 
     @abstractmethod
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         """Compute score.
 
         :param prediction: predicted labels
-        :param actual: DataTuple with the actual labels and the sensitive attributes
+        :param actual: EvalTuple with the actual labels and the sensitive attributes
         :returns: the score as a single number
         """
 

--- a/ethicml/metrics/npv.py
+++ b/ethicml/metrics/npv.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -19,6 +19,6 @@ class NPV(CfmMetric):
     _name: ClassVar[str] = "NPV"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         t_neg, _, f_neg, _ = self.confusion_matrix(prediction=prediction, actual=actual)
         return t_neg / (t_neg + f_neg)

--- a/ethicml/metrics/ppv.py
+++ b/ethicml/metrics/ppv.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -19,6 +19,6 @@ class PPV(CfmMetric):
     _name: ClassVar[str] = "PPV"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         _, f_pos, _, t_pos = self.confusion_matrix(prediction=prediction, actual=actual)
         return t_pos / (t_pos + f_pos)

--- a/ethicml/metrics/prob_neg.py
+++ b/ethicml/metrics/prob_neg.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -19,6 +19,6 @@ class ProbNeg(CfmMetric):
     _name: ClassVar[str] = "prob_neg"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         t_neg, _, f_neg, _ = self.confusion_matrix(prediction=prediction, actual=actual)
         return (t_neg + f_neg) / prediction.hard.size

--- a/ethicml/metrics/prob_outcome.py
+++ b/ethicml/metrics/prob_outcome.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction, SoftPrediction
+from ethicml.utility import EvalTuple, Prediction, SoftPrediction
 
 from .metric import Metric, MetricStaticName
 
@@ -19,7 +19,7 @@ class ProbOutcome(MetricStaticName):
     pos_class: int = 1
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         return (
             (prediction.soft.sum(axis=0)[self.pos_class] / prediction.hard.size).item()
             if isinstance(prediction, SoftPrediction)

--- a/ethicml/metrics/prob_pos.py
+++ b/ethicml/metrics/prob_pos.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -19,6 +19,6 @@ class ProbPos(CfmMetric):
     _name: ClassVar[str] = "prob_pos"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         _, f_pos, _, t_pos = self.confusion_matrix(prediction=prediction, actual=actual)
         return (t_pos + f_pos) / prediction.hard.size

--- a/ethicml/metrics/theil.py
+++ b/ethicml/metrics/theil.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 import numpy as np
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .metric import MetricStaticName
 
@@ -23,7 +23,7 @@ class Theil(MetricStaticName):
     _name: ClassVar[str] = "Theil_Index"
 
     @implements(MetricStaticName)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         y_true_df = actual.y
         y_pos_label = y_true_df.max()
 

--- a/ethicml/metrics/tnr.py
+++ b/ethicml/metrics/tnr.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -20,6 +20,6 @@ class TNR(CfmMetric):
     _name: ClassVar[str] = "TNR"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         t_neg, f_pos, _, _ = self.confusion_matrix(prediction=prediction, actual=actual)
         return t_neg / (t_neg + f_pos)

--- a/ethicml/metrics/tpr.py
+++ b/ethicml/metrics/tpr.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from ranzen import implements
 
-from ethicml.utility import DataTuple, Prediction
+from ethicml.utility import EvalTuple, Prediction
 
 from .confusion_matrix import CfmMetric
 from .metric import Metric
@@ -19,6 +19,6 @@ class TPR(CfmMetric):
     _name: ClassVar[str] = "TPR"
 
     @implements(Metric)
-    def score(self, prediction: Prediction, actual: DataTuple) -> float:
+    def score(self, prediction: Prediction, actual: EvalTuple) -> float:
         _, _, f_neg, t_pos = self.confusion_matrix(prediction=prediction, actual=actual)
         return t_pos / (t_pos + f_neg)

--- a/ethicml/preprocessing/biased_split.py
+++ b/ethicml/preprocessing/biased_split.py
@@ -102,9 +102,7 @@ def get_biased_subset(
     sy_equal_for_biased_ss, _ = _random_split(sy_equal, first_pcnt=sy_equal_fraction, seed=seed)
     sy_opp_for_biased_ss, _ = _random_split(sy_opposite, first_pcnt=sy_opp_fraction, seed=seed)
 
-    biased_subset = concat(
-        [sy_equal_for_biased_ss, sy_opp_for_biased_ss], axis="index", ignore_index=True
-    )
+    biased_subset = concat([sy_equal_for_biased_ss, sy_opp_for_biased_ss], ignore_index=True)
 
     if mix_fact == 0.0:
         # s and y should be very correlated in the biased subset
@@ -214,9 +212,7 @@ def get_biased_and_debiased_subsets(
             sy_opposite, first_pcnt=biased_pcnt * mixing_factor, seed=seed
         )
 
-    biased_subset = concat(
-        [sy_equal_for_biased_ss, sy_opp_for_biased_ss], axis="index", ignore_index=True
-    )
+    biased_subset = concat([sy_equal_for_biased_ss, sy_opp_for_biased_ss], ignore_index=True)
 
     # the debiased set is constructed from two sets of the same size
     min_size = min(len(sy_equal_for_debiased_ss), len(sy_opp_for_debiased_ss))
@@ -226,9 +222,7 @@ def get_biased_and_debiased_subsets(
 
     debiased_subset_part1 = sy_equal_for_debiased_ss.apply_to_joined_df(_get_equal_sized_subset)
     debiased_subset_part2 = sy_opp_for_debiased_ss.apply_to_joined_df(_get_equal_sized_subset)
-    debiased_subset = concat(
-        [debiased_subset_part1, debiased_subset_part2], axis="index", ignore_index=True
-    )
+    debiased_subset = concat([debiased_subset_part1, debiased_subset_part2], ignore_index=True)
 
     # s and y should not be correlated in the debiased subset
     assert abs(debiased_subset.s.corr(debiased_subset.y)) < 0.5

--- a/ethicml/preprocessing/biased_split.py
+++ b/ethicml/preprocessing/biased_split.py
@@ -108,8 +108,8 @@ def get_biased_subset(
         # s and y should be very correlated in the biased subset
         assert all(biased_subset.s == biased_subset.y)
 
-    biased_subset = biased_subset.replace(name=f"{data.name} - Biased (tm={mixing_factor})")
-    normal_subset = normal_subset.replace(name=f"{data.name} - Subset (tm={mixing_factor})")
+    biased_subset = biased_subset.rename(f"{data.name} - Biased (tm={mixing_factor})")
+    normal_subset = normal_subset.rename(f"{data.name} - Subset (tm={mixing_factor})")
     return biased_subset, normal_subset
 
 
@@ -231,8 +231,8 @@ def get_biased_and_debiased_subsets(
         # s and y should be very correlated in the biased subset
         assert biased_subset.s.corr(biased_subset.y) > 0.99
 
-    biased_subset = biased_subset.replace(name=f"{data.name} - Biased (tm={mixing_factor})")
-    debiased_subset = debiased_subset.replace(name=f"{data.name} - Debiased (tm={mixing_factor})")
+    biased_subset = biased_subset.rename(f"{data.name} - Biased (tm={mixing_factor})")
+    debiased_subset = debiased_subset.rename(f"{data.name} - Debiased (tm={mixing_factor})")
     return biased_subset, debiased_subset
 
 

--- a/ethicml/preprocessing/biased_split.py
+++ b/ethicml/preprocessing/biased_split.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import teext as tx
 
-from ethicml.utility.data_structures import DataTuple, concat_dt
+from ethicml.utility.data_structures import DataTuple, concat
 
 from .domain_adaptation import query_dt
 from .splits import DataSplitter, ProportionalSplit
@@ -102,7 +102,7 @@ def get_biased_subset(
     sy_equal_for_biased_ss, _ = _random_split(sy_equal, first_pcnt=sy_equal_fraction, seed=seed)
     sy_opp_for_biased_ss, _ = _random_split(sy_opposite, first_pcnt=sy_opp_fraction, seed=seed)
 
-    biased_subset = concat_dt(
+    biased_subset = concat(
         [sy_equal_for_biased_ss, sy_opp_for_biased_ss], axis="index", ignore_index=True
     )
 
@@ -214,7 +214,7 @@ def get_biased_and_debiased_subsets(
             sy_opposite, first_pcnt=biased_pcnt * mixing_factor, seed=seed
         )
 
-    biased_subset = concat_dt(
+    biased_subset = concat(
         [sy_equal_for_biased_ss, sy_opp_for_biased_ss], axis="index", ignore_index=True
     )
 
@@ -226,7 +226,7 @@ def get_biased_and_debiased_subsets(
 
     debiased_subset_part1 = sy_equal_for_debiased_ss.apply_to_joined_df(_get_equal_sized_subset)
     debiased_subset_part2 = sy_opp_for_debiased_ss.apply_to_joined_df(_get_equal_sized_subset)
-    debiased_subset = concat_dt(
+    debiased_subset = concat(
         [debiased_subset_part1, debiased_subset_part2], axis="index", ignore_index=True
     )
 

--- a/ethicml/preprocessing/scaling.py
+++ b/ethicml/preprocessing/scaling.py
@@ -61,4 +61,4 @@ def scale_continuous(
         new_feats[dataset.continuous_features] = scaler.transform(
             new_feats[dataset.continuous_features]
         )
-    return DataTuple.from_df(x=new_feats, s=datatuple.s, y=datatuple.y), scaler
+    return datatuple.replace(x=new_feats), scaler

--- a/ethicml/preprocessing/splits.py
+++ b/ethicml/preprocessing/splits.py
@@ -52,10 +52,10 @@ class SequentialSplit(DataSplitter):
         train_len = round(self.train_percentage * len(data))
 
         train = data.apply_to_joined_df(lambda df: df.iloc[:train_len].reset_index(drop=True))
-        train = train.replace(name=f"{data.name} - Train")
+        train = train.rename(f"{data.name} - Train")
 
         test = data.apply_to_joined_df(lambda df: df.iloc[train_len:].reset_index(drop=True))
-        test = test.replace(name=f"{data.name} - Test")
+        test = test.rename(f"{data.name} - Test")
 
         assert len(train) + len(test) == len(data)
         return train, test, {}

--- a/ethicml/preprocessing/splits.py
+++ b/ethicml/preprocessing/splits.py
@@ -87,7 +87,7 @@ def train_test_split(
     y_column = data.y.name
     assert isinstance(s_column, str) and isinstance(y_column, str)
 
-    all_data: pd.DataFrame = pd.concat([data.x, data.s, data.y], axis="columns")
+    all_data: pd.DataFrame = data.data
 
     all_data = shuffle_df(all_data, random_state=1)
 

--- a/ethicml/utility/data_structures.py
+++ b/ethicml/utility/data_structures.py
@@ -136,17 +136,11 @@ class SubgroupTuple(SubsetMixin):
         return iter([self.x, self.s])
 
     def replace(
-        self,
-        *,
-        x: Optional[pd.DataFrame] = None,
-        s: Optional[pd.Series] = None,
-        name: Optional[str] = None,
+        self, *, x: Optional[pd.DataFrame] = None, s: Optional[pd.Series] = None
     ) -> SubgroupTuple:
         """Create a copy of the SubgroupTuple but change the given values."""
         return SubgroupTuple.from_df(
-            x=x if x is not None else self.x,
-            s=s if s is not None else self.s,
-            name=name if name is not None else self.name,
+            x=x if x is not None else self.x, s=s if s is not None else self.s, name=self.name
         )
 
     def replace_data(self, data: pd.DataFrame) -> SubgroupTuple:
@@ -243,14 +237,13 @@ class DataTuple(SubsetMixin):
         x: Optional[pd.DataFrame] = None,
         s: Optional[pd.Series] = None,
         y: Optional[pd.Series] = None,
-        name: Optional[str] = None,
     ) -> DataTuple:
         """Create a copy of the DataTuple but change the given values."""
         return DataTuple.from_df(
             x=x if x is not None else self.x,
             s=s if s is not None else self.s,
             y=y if y is not None else self.y,
-            name=name if name is not None else self.name,
+            name=self.name,
         )
 
     def rename(self, name: str) -> DataTuple:
@@ -353,17 +346,11 @@ class LabelTuple(SubsetMixin):
         return iter([self.s, self.y])
 
     def replace(
-        self,
-        *,
-        s: Optional[pd.Series] = None,
-        y: Optional[pd.Series] = None,
-        name: Optional[str] = None,
+        self, *, s: Optional[pd.Series] = None, y: Optional[pd.Series] = None
     ) -> LabelTuple:
         """Create a copy of the LabelTuple but change the given values."""
         return LabelTuple.from_df(
-            s=s if s is not None else self.s,
-            y=y if y is not None else self.y,
-            name=name if name is not None else self.name,
+            s=s if s is not None else self.s, y=y if y is not None else self.y, name=self.name
         )
 
     def rename(self, name: str) -> LabelTuple:

--- a/ethicml/utility/data_structures.py
+++ b/ethicml/utility/data_structures.py
@@ -17,6 +17,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
     Union,
 )
 from typing_extensions import Final, Literal, TypeAlias
@@ -28,6 +29,7 @@ from ranzen import enum_name_str
 __all__ = [
     "ClassifierType",
     "DataTuple",
+    "EvalTuple",
     "FairnessType",
     "HyperParamType",
     "HyperParamValue",
@@ -36,11 +38,11 @@ __all__ = [
     "Results",
     "ResultsAggregator",
     "SoftPrediction",
+    "SubgroupTuple",
     "TestTuple",
     "TrainTestPair",
     "aggregate_results",
-    "concat_dt",
-    "concat_tt",
+    "concat",
     "filter_and_map_results",
     "filter_results",
     "make_results",
@@ -60,7 +62,7 @@ class PandasIndex(Enum):
 
 
 @dataclass
-class TestTuple:
+class SubgroupTuple:
     """A tuple of dataframes for the features and the sensitive attribute."""
 
     __slots__ = ("data", "s_column", "name")
@@ -73,9 +75,9 @@ class TestTuple:
 
     @classmethod
     def from_df(
-        cls, x: pd.DataFrame, s: pd.Series[int], *, name: Optional[str] = None
-    ) -> TestTuple:
-        """Make a TestTuple."""
+        cls, x: pd.DataFrame, s: pd.Series[int], name: Optional[str] = None
+    ) -> SubgroupTuple:
+        """Make a SubgroupTuple."""
         s_column = s.name
         assert isinstance(s_column, str)
         assert len(x) == len(s), "data has to have the same length"
@@ -105,16 +107,24 @@ class TestTuple:
         x: Optional[pd.DataFrame] = None,
         s: Optional[pd.Series] = None,
         name: Optional[str] = None,
-    ) -> TestTuple:
-        """Create a copy of the TestTuple but change the given values."""
-        return TestTuple.from_df(
+    ) -> SubgroupTuple:
+        """Create a copy of the SubgroupTuple but change the given values."""
+        return SubgroupTuple.from_df(
             x=x if x is not None else self.x,
             s=s if s is not None else self.s,
             name=name if name is not None else self.name,
         )
 
+    def replace_data(self, data: pd.DataFrame) -> SubgroupTuple:
+        """Make a copy of the DataTuple but change the underlying data."""
+        return SubgroupTuple(data=data, s_column=self.s_column, name=self.name)
+
+    def rename(self, name: str) -> SubgroupTuple:
+        """Change only the name."""
+        return SubgroupTuple(data=self.data, s_column=self.s_column, name=name)
+
     def to_npz(self, data_path: Path) -> None:
-        """Save TestTuple as an npz file.
+        """Save SubgroupTuple as an npz file.
 
         :param data_path: Path to save the npz file.
         """
@@ -125,7 +135,7 @@ class TestTuple:
         )
 
     @classmethod
-    def from_npz(cls, data_path: Path) -> TestTuple:
+    def from_npz(cls, data_path: Path) -> SubgroupTuple:
         """Load test tuple from npz file.
 
         :param data_path: Path to load the npz file.
@@ -141,11 +151,14 @@ class TestTuple:
 
 
 @dataclass
-class DataTuple(TestTuple):
+class DataTuple:
     """A tuple of dataframes for the features, the sensitive attribute and the class labels."""
 
     __slots__ = ("data", "s_column", "y_column", "name")
+    data: pd.DataFrame
+    s_column: str
     y_column: str
+    name: str | None
 
     def __post_init__(self) -> None:
         assert self.s_column in self.data.columns, f"column {self.s_column} not present"
@@ -153,7 +166,7 @@ class DataTuple(TestTuple):
 
     @classmethod
     def from_df(
-        cls, x: pd.DataFrame, s: pd.Series[int], *, y: pd.Series[int], name: Optional[str] = None
+        cls, x: pd.DataFrame, s: pd.Series[int], y: pd.Series[int], name: Optional[str] = None
     ) -> DataTuple:
         """Make a DataTuple."""
         s_column = s.name
@@ -173,17 +186,26 @@ class DataTuple(TestTuple):
         return self.data.drop([self.s_column, self.y_column], inplace=False, axis="columns")
 
     @property
+    def s(self) -> pd.Series[int]:
+        """Getter for property s."""
+        return self.data[self.s_column]
+
+    @property
     def y(self) -> pd.Series[int]:
         """Getter for property y."""
         return self.data[self.y_column]
 
     def __iter__(self) -> Iterator[Union[pd.DataFrame, pd.Series]]:
-        """Overwrite __iter__ magic method."""
+        """Overwrite magic method __iter__."""
         return iter([self.x, self.s, self.y])
 
-    def remove_y(self) -> TestTuple:
-        """Convert the DataTuple instance to a TestTuple instance."""
-        return TestTuple(
+    def __len__(self) -> int:
+        """Overwrite __len__ magic method."""
+        return len(self.data)
+
+    def remove_y(self) -> SubgroupTuple:
+        """Convert the DataTuple instance to a SubgroupTuple instance."""
+        return SubgroupTuple(
             data=self.data.drop(self.y_column, inplace=False, axis="columns"),
             s_column=self.s_column,
             name=self.name,
@@ -204,6 +226,10 @@ class DataTuple(TestTuple):
             y=y if y is not None else self.y,
             name=name if name is not None else self.name,
         )
+
+    def rename(self, name: str) -> DataTuple:
+        """Change only the name."""
+        return DataTuple(data=self.data, s_column=self.s_column, y_column=self.y_column, name=name)
 
     def replace_data(self, data: pd.DataFrame) -> DataTuple:
         """Make a copy of the DataTuple but change the underlying data."""
@@ -254,6 +280,135 @@ class DataTuple(TestTuple):
                 y=pd.Series(data["y"], name=data["y_names"][0]),
                 name=name or None,
             )
+
+
+@dataclass
+class LabelTuple:
+    """A tuple of dataframes for the features, the sensitive attribute and the class labels."""
+
+    __slots__ = ("data", "s_column", "y_column", "name")
+    data: pd.DataFrame
+    s_column: str
+    y_column: str
+    name: str | None
+
+    def __post_init__(self) -> None:
+        assert self.s_column in self.data.columns, f"column {self.s_column} not present"
+        assert self.y_column in self.data.columns, f"column {self.y_column} not present"
+
+    @classmethod
+    def from_df(
+        cls, s: pd.Series[int], y: pd.Series[int], name: Optional[str] = None
+    ) -> LabelTuple:
+        """Make a LabelTuple."""
+        s_column = s.name
+        y_column = y.name
+        assert isinstance(s_column, str) and isinstance(y_column, str)
+        assert len(s) == len(y), "data has to have the same length"
+        return cls(
+            data=pd.concat([s, y], axis="columns", sort=False),
+            s_column=s_column,
+            y_column=y_column,
+            name=name,
+        )
+
+    @property
+    def s(self) -> pd.Series[int]:
+        """Getter for property s."""
+        return self.data[self.s_column]
+
+    @property
+    def y(self) -> pd.Series[int]:
+        """Getter for property y."""
+        return self.data[self.y_column]
+
+    def __iter__(self) -> Iterator[Union[pd.DataFrame, pd.Series]]:
+        """Overwrite magic method __iter__."""
+        return iter([self.s, self.y])
+
+    def __len__(self) -> int:
+        """Overwrite __len__ magic method."""
+        return len(self.data)
+
+    def remove_y(self) -> SubgroupTuple:
+        """Convert the LabelTuple instance to a SubgroupTuple instance."""
+        return SubgroupTuple(
+            data=self.data.drop(self.y_column, inplace=False, axis="columns"),
+            s_column=self.s_column,
+            name=self.name,
+        )
+
+    def replace(
+        self,
+        *,
+        s: Optional[pd.Series] = None,
+        name: Optional[str] = None,
+        y: Optional[pd.Series] = None,
+    ) -> LabelTuple:
+        """Create a copy of the LabelTuple but change the given values."""
+        return LabelTuple.from_df(
+            s=s if s is not None else self.s,
+            y=y if y is not None else self.y,
+            name=name if name is not None else self.name,
+        )
+
+    def rename(self, name: str) -> LabelTuple:
+        """Change only the name."""
+        return LabelTuple(data=self.data, s_column=self.s_column, y_column=self.y_column, name=name)
+
+    def replace_data(self, data: pd.DataFrame) -> LabelTuple:
+        """Make a copy of the LabelTuple but change the underlying data."""
+        return LabelTuple(data=data, s_column=self.s_column, y_column=self.y_column, name=self.name)
+
+    def apply_to_joined_df(self, mapper: Callable[[pd.DataFrame], pd.DataFrame]) -> LabelTuple:
+        """Concatenate the dataframes in the LabelTuple and then apply a function to it.
+
+        :param mapper: A function that takes a dataframe and returns a dataframe.
+        """
+        return self.replace_data(data=mapper(self.data))
+
+    def get_n_samples(self, num: int = 500) -> LabelTuple:
+        """Get the first elements of the dataset.
+
+        :param num: How many samples to take for subset. (Default: 500)
+        :returns: Subset of training data.
+        """
+        return self.replace_data(data=self.data.iloc[:num])
+
+    def get_s_subset(self, s: int) -> LabelTuple:
+        """Return a subset of the LabelTuple where S=s."""
+        return self.replace_data(data=self.data[self.s == s])
+
+    def to_npz(self, data_path: Path) -> None:
+        """Save LabelTuple as an npz file.
+
+        :param data_path: Path to the npz file.
+        """
+        write_as_npz(
+            data_path,
+            dict(s=self.s, y=self.y),
+            dict(name=np.array(self.name if self.name is not None else "")),
+        )
+
+    @classmethod
+    def from_npz(cls, data_path: Path) -> LabelTuple:
+        """Load data tuple from npz file.
+
+        :param data_path: Path to the npz file.
+        """
+        with data_path.open("rb") as data_file:
+            data = np.load(data_file)
+            name = data["name"].item()
+            return cls.from_df(
+                s=pd.Series(data["s"], name=data["s_names"][0]),
+                y=pd.Series(data["y"], name=data["y_names"][0]),
+                name=name or None,
+            )
+
+
+TestTuple: TypeAlias = Union[SubgroupTuple, DataTuple]
+EvalTuple: TypeAlias = Union[LabelTuple, DataTuple]
+T = TypeVar("T", SubgroupTuple, DataTuple)
 
 
 class Prediction:
@@ -355,46 +510,19 @@ def write_as_npz(
     np.savez(data_path, **as_numpy, **column_names, **extra)
 
 
-def concat_dt(
-    datatup_list: Sequence[DataTuple],
-    axis: AxisType = "index",
+def concat(
+    datatup_list: Sequence[T],
     ignore_index: bool = False,
-) -> DataTuple:
+) -> T:
     """Concatenate the data tuples in the given list.
 
     :param datatup_list: List of data tuples to concatenate.
-    :param axis: Axis to concatenate on. (Default: 'index')
     :param ignore_index: Ignore the index of the dataframes. (Default: False)
     """
-    return DataTuple.from_df(
-        x=pd.concat(
-            [dt.x for dt in datatup_list], axis=axis, sort=False, ignore_index=ignore_index
-        ),
-        s=pd.concat(
-            [dt.s for dt in datatup_list], axis=axis, sort=False, ignore_index=ignore_index
-        ),
-        y=pd.concat(
-            [dt.y for dt in datatup_list], axis=axis, sort=False, ignore_index=ignore_index
-        ),
-        name=datatup_list[0].name,
+    data: pd.DataFrame = pd.concat(
+        [dt.data for dt in datatup_list], axis="index", sort=False, ignore_index=ignore_index
     )
-
-
-def concat_tt(
-    datatup_list: List[TestTuple],
-    axis: AxisType = "index",
-    ignore_index: bool = False,
-) -> TestTuple:
-    """Concatenate the test tuples in the given list."""
-    return TestTuple.from_df(
-        x=pd.concat(
-            [dt.x for dt in datatup_list], axis=axis, sort=False, ignore_index=ignore_index
-        ),
-        s=pd.concat(
-            [dt.s for dt in datatup_list], axis=axis, sort=False, ignore_index=ignore_index
-        ),
-        name=datatup_list[0].name,
-    )
+    return datatup_list[0].replace_data(data)
 
 
 @enum_name_str

--- a/ethicml/visualisation/plot.py
+++ b/ethicml/visualisation/plot.py
@@ -39,7 +39,7 @@ def maybe_tsne(data: DataTuple) -> Tuple[pd.DataFrame, str, str]:
         x1_name = "tsne1"
         x2_name = "tsne2"
     else:
-        amalgamated = pd.concat([data.x, data.s, data.y], axis="columns")
+        amalgamated = data.data
         x1_name = f"{columns[0]}"
         x2_name = f"{columns[1]}"
     return amalgamated, x1_name, x2_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 import ethicml as em
-from ethicml import DataTuple, TrainTestPair
+from ethicml import DataTuple, TrainTestPair, TrainValPair
 
 
 @pytest.fixture(scope="session")
@@ -21,17 +21,17 @@ def toy_train_test() -> TrainTestPair:
     train: DataTuple
     test: DataTuple
     train, test = em.train_test_split(data, random_seed=0)
-    return TrainTestPair(train, test)
+    return TrainTestPair(train, test.remove_y())
 
 
 @pytest.fixture(scope="session")
-def toy_train_val() -> TrainTestPair:
+def toy_train_val() -> TrainValPair:
     """By making this a fixture, pytest can cache the result."""
     data: DataTuple = em.Toy().load()
     train: DataTuple
     test: DataTuple
     train, test = em.train_test_split(data)
-    return TrainTestPair(train, test)
+    return TrainValPair(train, test)
 
 
 @pytest.fixture(scope="module")

--- a/tests/loading_data_test.py
+++ b/tests/loading_data_test.py
@@ -921,7 +921,7 @@ def test_concat():
     s = pd.Series(name="b", data=[5])
     y = pd.Series(name="c", data=[6])
     data2 = DataTuple.from_df(x=x, s=s, y=y, name="test_tuple")
-    data3 = em.concat([data1, data2], axis="index", ignore_index=True)
+    data3 = em.concat([data1, data2], ignore_index=True)
     pd.testing.assert_frame_equal(data3.x, pd.DataFrame(columns=["a"], data=[[1], [4]]))
     pd.testing.assert_series_equal(data3.s, pd.Series(name="b", data=[2, 5]))
     pd.testing.assert_series_equal(data3.y, pd.Series(name="c", data=[3, 6]))

--- a/tests/loading_data_test.py
+++ b/tests/loading_data_test.py
@@ -921,7 +921,7 @@ def test_concat():
     s = pd.Series(name="b", data=[5])
     y = pd.Series(name="c", data=[6])
     data2 = DataTuple.from_df(x=x, s=s, y=y, name="test_tuple")
-    data3 = em.concat_dt([data1, data2], axis="index", ignore_index=True)
+    data3 = em.concat([data1, data2], axis="index", ignore_index=True)
     pd.testing.assert_frame_equal(data3.x, pd.DataFrame(columns=["a"], data=[[1], [4]]))
     pd.testing.assert_series_equal(data3.s, pd.Series(name="b", data=[2, 5]))
     pd.testing.assert_series_equal(data3.y, pd.Series(name="c", data=[3, 6]))

--- a/tests/metrics/metric_test.py
+++ b/tests/metrics/metric_test.py
@@ -93,9 +93,7 @@ METRICS = [
 
 @pytest.mark.parametrize("metric,expected", METRICS)
 def test_on_label_tuple(metric: Metric, expected: float) -> None:
-    preds = Prediction(hard=pd.Series([0, 0, 1, 1]))
-    targets = LabelTuple.from_np(
-        s=np.array([0, 1, 1, 1]), y=np.array([0, 1, 0, 1]), s_name="s", y_name="y"
-    )
+    preds = Prediction.from_np(np.array([0, 0, 1, 1]))
+    targets = LabelTuple.from_np(s=np.array([0, 1, 1, 1]), y=np.array([0, 1, 0, 1]))
     score = metric.score(preds, targets)
     assert score == approx(expected, abs=0.001)

--- a/tests/metrics/nonparamaterized_metric_test.py
+++ b/tests/metrics/nonparamaterized_metric_test.py
@@ -20,6 +20,7 @@ from ethicml import (
     Accuracy,
     BalancedTestSplit,
     DataTuple,
+    EvalTuple,
     InAlgorithm,
     LabelOutOfBounds,
     NonBinaryToy,
@@ -319,14 +320,14 @@ def test_nb_tnr():
     }
 
 
-def _compute_di(preds: Prediction, actual: DataTuple) -> float:
+def _compute_di(preds: Prediction, actual: EvalTuple) -> float:
     ratios = em.ratio_per_sensitive_attribute(
         em.metric_per_sensitive_attribute(preds, actual, ProbPos())
     )
     return next(iter(ratios.values()))
 
 
-def _compute_inv_cv(preds: Prediction, actual: DataTuple) -> float:
+def _compute_inv_cv(preds: Prediction, actual: EvalTuple) -> float:
     diffs = em.diff_per_sensitive_attribute(
         em.metric_per_sensitive_attribute(preds, actual, ProbPos())
     )

--- a/tests/models_test/inprocess_test/models_inprocessing_test.py
+++ b/tests/models_test/inprocess_test/models_inprocessing_test.py
@@ -25,7 +25,6 @@ from ethicml import (
     DPOracle,
     FairDummies,
     FairnessType,
-    InAlgoArgs,
     InAlgorithm,
     InAlgorithmSubprocess,
     Kamiran,
@@ -37,6 +36,7 @@ from ethicml import (
     Prediction,
     Toy,
     TrainTestPair,
+    TrainValPair,
     evaluate_models,
     load_data,
     train_test_split,
@@ -118,9 +118,9 @@ INPROCESS_TESTS = [
 
 
 @pytest.mark.parametrize("name,model,num_pos", INPROCESS_TESTS)
-def test_inprocess(toy_train_test: TrainTestPair, name: str, model: InAlgorithm, num_pos: int):
+def test_inprocess(toy_train_val: TrainValPair, name: str, model: InAlgorithm, num_pos: int):
     """Test an inprocess model."""
-    train, test = toy_train_test
+    train, test = toy_train_val
 
     assert isinstance(model, InAlgorithm)
     assert model is not None
@@ -149,10 +149,10 @@ def test_kamiran_weights(toy_train_test: TrainTestPair):
 
 @pytest.mark.parametrize("name,model,num_pos", INPROCESS_TESTS)
 def test_inprocess_sep_train_pred(
-    toy_train_test: TrainTestPair, name: str, model: InAlgorithm, num_pos: int
+    toy_train_val: TrainValPair, name: str, model: InAlgorithm, num_pos: int
 ):
     """Test an inprocess model with distinct train and predict steps."""
-    train, test = toy_train_test
+    train, test = toy_train_val
 
     assert isinstance(model, InAlgorithm)
     assert model is not None

--- a/tests/models_test/inprocess_test/zafar_test.py
+++ b/tests/models_test/inprocess_test/zafar_test.py
@@ -122,7 +122,7 @@ def test_zafar(toy_train_test: TrainTestPair, zafar_teardown: None) -> None:
 
     # ==================== Zafar Equality of Opportunity ========================
     zafar_eq_opp: InAlgorithm = ZafarEqOpp()
-    assert zafar_eq_opp.name == "ZafarEqOpp, τ=5.0, μ=1.2"
+    assert zafar_eq_opp.name == "ZafarEqOpp, τ=5.0, μ=1.2 ε=0.0001"
 
     predictions = zafar_eq_opp.run(train, test)
     assert np.count_nonzero(predictions.hard.values == 1) == 40

--- a/tests/models_test/inprocess_test/zafar_test.py
+++ b/tests/models_test/inprocess_test/zafar_test.py
@@ -132,7 +132,7 @@ def test_zafar(toy_train_test: TrainTestPair, zafar_teardown: None) -> None:
 
     # ==================== Zafar Equalised Odds ========================
     zafar_eq_odds: InAlgorithm = ZafarEqOdds()
-    assert zafar_eq_odds.name == "ZafarEqOdds, τ=5.0, μ=1.2"
+    assert zafar_eq_odds.name == "ZafarEqOdds, τ=5.0, μ=1.2 ε=0.0001"
 
     predictions = zafar_eq_odds.run(train, test)
     assert np.count_nonzero(predictions.hard.values == 1) == 40

--- a/tests/models_test/postprocess_test/models_postprocessing_test.py
+++ b/tests/models_test/postprocess_test/models_postprocessing_test.py
@@ -30,7 +30,7 @@ def test_post(
 ) -> None:
     """Test the dem par flipping method."""
     train, test = toy_train_test
-    train_test = em.concat_tt([train, test], ignore_index=True)
+    train_test = em.concat([train, test], ignore_index=True)
 
     in_model: InAlgorithm = LR()
     assert in_model is not None
@@ -68,7 +68,7 @@ def test_post_sep_fit_pred(
 ) -> None:
     """Test the dem par flipping method."""
     train, test = toy_train_test
-    train_test = em.concat_tt([train, test], ignore_index=True)
+    train_test = em.concat([train, test], ignore_index=True)
 
     in_model: InAlgorithm = LR()
     assert in_model is not None
@@ -100,7 +100,7 @@ def test_dp_flip_inverted_s(toy_train_test: TrainValPair) -> None:
     train, test = toy_train_test
     train = train.replace(s=1 - train.s)
     test = test.replace(s=1 - test.s)
-    train_test = em.concat_tt([train, test], ignore_index=True)
+    train_test = em.concat([train, test], ignore_index=True)
 
     in_model: InAlgorithm = LR()
     assert in_model is not None

--- a/tests/models_test/postprocess_test/models_postprocessing_test.py
+++ b/tests/models_test/postprocess_test/models_postprocessing_test.py
@@ -26,10 +26,10 @@ class PostprocessTest(NamedTuple):
     ],
 )
 def test_post(
-    toy_train_test: TrainValPair, post_model: PostAlgorithm, name: str, num_pos: int
+    toy_train_val: TrainValPair, post_model: PostAlgorithm, name: str, num_pos: int
 ) -> None:
     """Test the dem par flipping method."""
-    train, test = toy_train_test
+    train, test = toy_train_val
     train_test = em.concat([train, test], ignore_index=True)
 
     in_model: InAlgorithm = LR()
@@ -64,10 +64,10 @@ def test_post(
     ],
 )
 def test_post_sep_fit_pred(
-    toy_train_test: TrainValPair, post_model: PostAlgorithm, name: str, num_pos: int
+    toy_train_val: TrainValPair, post_model: PostAlgorithm, name: str, num_pos: int
 ) -> None:
     """Test the dem par flipping method."""
-    train, test = toy_train_test
+    train, test = toy_train_val
     train_test = em.concat([train, test], ignore_index=True)
 
     in_model: InAlgorithm = LR()
@@ -95,9 +95,9 @@ def test_post_sep_fit_pred(
             assert pytest.approx(diff, abs=1e-2) == 0
 
 
-def test_dp_flip_inverted_s(toy_train_test: TrainValPair) -> None:
+def test_dp_flip_inverted_s(toy_train_val: TrainValPair) -> None:
     """Test the dem par flipping method."""
-    train, test = toy_train_test
+    train, test = toy_train_val
     train = train.replace(s=1 - train.s)
     test = test.replace(s=1 - test.s)
     train_test = em.concat([train, test], ignore_index=True)

--- a/tests/models_test/preprocess_test/models_preprocessing_test.py
+++ b/tests/models_test/preprocess_test/models_preprocessing_test.py
@@ -18,7 +18,7 @@ from ethicml import (
     FairnessType,
     InAlgorithm,
     PreAlgorithm,
-    TrainTestPair,
+    TrainValPair,
     Upsampler,
     UpsampleStrategy,
     Zemel,
@@ -87,9 +87,9 @@ METHOD_LIST_EXTENSION = [
 
 
 @pytest.mark.parametrize("model,name,num_pos", METHOD_LIST + METHOD_LIST_EXTENSION)
-def test_pre(toy_train_test: TrainTestPair, model: PreAlgorithm, name: str, num_pos: int):
+def test_pre(toy_train_val: TrainValPair, model: PreAlgorithm, name: str, num_pos: int):
     """Test preprocessing."""
-    train, test = toy_train_test
+    train, test = toy_train_val
 
     svm_model: InAlgorithm = SVM()
 
@@ -112,10 +112,10 @@ def test_pre(toy_train_test: TrainTestPair, model: PreAlgorithm, name: str, num_
 
 @pytest.mark.parametrize("model,name,num_pos", METHOD_LIST)
 def test_pre_sep_fit_transform(
-    toy_train_test: TrainTestPair, model: PreAlgorithm, name: str, num_pos: int
+    toy_train_val: TrainValPair, model: PreAlgorithm, name: str, num_pos: int
 ):
     """Test preprocessing."""
-    train, test = toy_train_test
+    train, test = toy_train_val
 
     svm_model: InAlgorithm = SVM()
 
@@ -138,9 +138,9 @@ def test_pre_sep_fit_transform(
 
 
 @pytest.mark.parametrize("model,name,num_pos", METHOD_LIST)
-def test_threaded_pre(toy_train_test: TrainTestPair, model: PreAlgorithm, name: str, num_pos: int):
+def test_threaded_pre(toy_train_val: TrainValPair, model: PreAlgorithm, name: str, num_pos: int):
     """Test vfae."""
-    train, test = toy_train_test
+    train, test = toy_train_val
 
     svm_model: InAlgorithm = SVM()
     assert svm_model is not None

--- a/tests/models_test/preprocess_test/models_preprocessing_test.py
+++ b/tests/models_test/preprocess_test/models_preprocessing_test.py
@@ -18,6 +18,7 @@ from ethicml import (
     FairnessType,
     InAlgorithm,
     PreAlgorithm,
+    TrainTestPair,
     TrainValPair,
     Upsampler,
     UpsampleStrategy,
@@ -87,9 +88,9 @@ METHOD_LIST_EXTENSION = [
 
 
 @pytest.mark.parametrize("model,name,num_pos", METHOD_LIST + METHOD_LIST_EXTENSION)
-def test_pre(toy_train_val: TrainValPair, model: PreAlgorithm, name: str, num_pos: int):
+def test_pre(toy_train_test: TrainTestPair, model: PreAlgorithm, name: str, num_pos: int):
     """Test preprocessing."""
-    train, test = toy_train_val
+    train, test = toy_train_test
 
     svm_model: InAlgorithm = SVM()
 
@@ -138,9 +139,9 @@ def test_pre_sep_fit_transform(
 
 
 @pytest.mark.parametrize("model,name,num_pos", METHOD_LIST)
-def test_threaded_pre(toy_train_val: TrainValPair, model: PreAlgorithm, name: str, num_pos: int):
+def test_threaded_pre(toy_train_test: TrainTestPair, model: PreAlgorithm, name: str, num_pos: int):
     """Test vfae."""
-    train, test = toy_train_val
+    train, test = toy_train_test
 
     svm_model: InAlgorithm = SVM()
     assert svm_model is not None

--- a/tests/run_algorithm_test.py
+++ b/tests/run_algorithm_test.py
@@ -24,14 +24,14 @@ def test_can_load_test_data(toy_train_test: em.TrainTestPair):
     assert test is not None
 
 
-def test_run_parallel(toy_train_test: em.TrainTestPair):
+def test_run_parallel(toy_train_val: em.TrainValPair):
     """Test run parallel."""
 
-    data0 = toy_train_test
-    data1 = toy_train_test
+    data0 = toy_train_val
+    data1 = toy_train_val
     result = run_in_parallel(
         algos=[em.LR(), em.SVM(), em.Majority()],
-        data=[em.TrainTestPair(*data0), em.TrainTestPair(*data1)],
+        data=[em.TrainValPair(*data0), em.TrainValPair(*data1)],
         seeds=[0, 0],
         num_jobs=2,
     )

--- a/tests/saving_data_test.py
+++ b/tests/saving_data_test.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ethicml import DataTuple, InAlgoArgs, InAlgorithmSubprocess, Prediction, TestTuple
+from ethicml import DataTuple, InAlgoArgs, InAlgorithmSubprocess, Prediction, SubgroupTuple
 from ethicml.algorithms.inprocess.in_algorithm import HyperParamType
 
 NPZ: Final[str] = "test.npz"
@@ -106,7 +106,7 @@ def test_dataset_name_none() -> None:
 def test_dataset_name_with_spaces() -> None:
     """Tests that a dataset name can contain spaces and special chars."""
     name = "This is a very@#$%^&*((())) complicated name"
-    datatup = TestTuple.from_df(
+    datatup = SubgroupTuple.from_df(
         x=pd.DataFrame([3.0], columns=["a1"]), s=pd.Series([4.0], name="b2"), name=name
     )
     with TemporaryDirectory() as tmpdir:
@@ -114,7 +114,7 @@ def test_dataset_name_with_spaces() -> None:
         path = tmp_path / "pytest2.npz"
         datatup.to_npz(path)
         # reload from feather file
-        reloaded = TestTuple.from_npz(path)
+        reloaded = SubgroupTuple.from_npz(path)
     assert name == reloaded.name
     pd.testing.assert_frame_equal(datatup.x, reloaded.x)
     pd.testing.assert_series_equal(datatup.s, reloaded.s)

--- a/tests/visualisation_test.py
+++ b/tests/visualisation_test.py
@@ -44,7 +44,7 @@ def test_plot_tsne(toy_train_test: TrainTestPair):
 def test_plot_no_tsne(toy_train_test: TrainTestPair):
     """Test plot."""
     train, _ = toy_train_test
-    train = DataTuple.from_df(x=train.x[train.x.columns[:2]], s=train.s, y=train.y)
+    train = train.replace(x=train.x[train.x.columns[:2]])
     save_2d_plot(train, "./plots/test.png")
 
 


### PR DESCRIPTION
And also introduce the new `LabelTuple`.

The names are all subject to change. I can easily rename them with my editor.

Myles might be excited about this:

```python
preds = Prediction(hard=pd.Series([0, 0, 1, 1]))
targets = LabelTuple.from_np(
    s=np.array([0, 1, 1, 1]), y=np.array([0, 1, 0, 1]), s_name="s", y_name="y"
)
score = metric.score(preds, targets)
```